### PR TITLE
Fix state synchronization in DesignCanvas handleUp

### DIFF
--- a/frontend/src/components/DesignCanvas.jsx
+++ b/frontend/src/components/DesignCanvas.jsx
@@ -369,6 +369,8 @@ export const DesignCanvas = ({ viewState, setViewState, assets, designTargetId, 
                     finalAsset = { ...finalAsset, ...bounds };
                 }
             }
+            setLocalAsset(finalAsset);
+            localAssetRef.current = finalAsset;
             setLocalAssets(prev => prev.map(a => a.id === designTargetId ? finalAsset : a));
         }
         dragRef.current = { mode: 'idle' };

--- a/frontend/vite.log
+++ b/frontend/vite.log
@@ -3,25 +3,7 @@
 > vite
 
 
-  VITE v3.2.11  ready in 529 ms
+  VITE v3.2.11  ready in 532 ms
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose
-9:56:09 AM [vite] hmr update /src/components/Ruler.jsx
-hmr update /src/style.css
-9:56:45 AM [vite] page reload dist/index.html
-10:40:13 AM [vite] hmr update /src/App.jsx
-hmr update /src/style.css
-hmr update /src/pages/Home.jsx
-hmr update /src/style.css
-hmr update /src/pages/Library.jsx
-hmr update /src/style.css
-hmr update /src/pages/Editor.jsx
-hmr update /src/style.css
-hmr update /src/components/DesignCanvas.jsx
-hmr update /src/style.css
-hmr update /src/components/DesignProperties.jsx
-hmr update /src/style.css
-hmr update /src/style.css
-hmr update /src/style.css
-10:40:49 AM [vite] page reload dist/index.html


### PR DESCRIPTION
Updated `handleUp` in `frontend/src/components/DesignCanvas.jsx` to update `localAsset` and `localAssetRef.current` in addition to `setLocalAssets`. This aligns the logic with `handleDeleteShape` and prevents a rendering inconsistency where the bounding box (AABB) would lag behind the shape immediately after a drag operation until the next render. Verified visually with Playwright.

---
*PR created automatically by Jules for task [10709457137616173399](https://jules.google.com/task/10709457137616173399) started by @imohiyoko*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imohiyoko/roomgenerator/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed local state synchronization during asset operations to ensure consistency before persisting changes to the main store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->