### PR TITLE
Fix inline delete button selection state in DesignProperties

### DIFF
--- a/frontend/src/components/DesignProperties.jsx
+++ b/frontend/src/components/DesignProperties.jsx
@@ -524,7 +524,7 @@ export const DesignProperties = () => {
                                 className={`flex justify-between items-center text-xs p-1 rounded border cursor-pointer ${selectedShapeIndices.includes(i) ? 'bg-blue-50 border-blue-300' : 'hover:bg-gray-50'}`}
                             >
                                 <span className="font-bold text-gray-500">#{i + 1} {s.type}</span>
-                            <button onClick={(e) => { e.stopPropagation(); if (!confirm('削除？')) return; const newEntities = (asset.entities || []).filter((_, idx) => idx !== i); setLocalAssets(p => p.map(a => a.id === designTargetId ? updateAssetEntities(a, newEntities) : a)); setSelectedShapeIndices(p => p.filter(idx => idx !== i)); }} className="text-red-400 hover:text-red-600 px-1">×</button>
+                        <button onClick={(e) => { e.stopPropagation(); if (!confirm('削除？')) return; const newEntities = (asset.entities || []).filter((_, idx) => idx !== i); setLocalAssets(p => p.map(a => a.id === designTargetId ? updateAssetEntities(a, newEntities) : a)); setSelectedShapeIndices([]); }} className="text-red-400 hover:text-red-600 px-1">×</button>
                             </div>
                         ))}
                     </div>


### PR DESCRIPTION
Fixed a bug where deleting a shape via the inline delete button in `DesignProperties.jsx` would not update the selection state correctly, potentially leading to out-of-bounds index access or incorrect selection highlighting. The selection is now cleared upon deletion, consistent with the canvas behavior.

---
*PR created automatically by Jules for task [11437789804517130283](https://jules.google.com/task/11437789804517130283) started by @imohiyoko*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imohiyoko/roomgenerator/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Selection Behavior**: Modified selection clearing behavior when deleting items. Previously, other selected items remained selected; now the entire selection clears upon deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->