### PR TITLE
Fix drag state stuck on delete cancel in DesignCanvas

### DIFF
--- a/frontend/src/components/DesignCanvas.jsx
+++ b/frontend/src/components/DesignCanvas.jsx
@@ -176,7 +176,7 @@ const DesignCanvasRender = ({ viewState, asset, entities, selectedShapeIndices, 
                                                 const maxY = Math.max(...s.points.map(p => p.y));
 
                                                 return (
-                                                    <g transform={`translate(${maxX * BASE_SCALE + 10}, ${toSvgY(maxY) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(i)}>
+                                                    <g transform={`translate(${maxX * BASE_SCALE + 10}, ${toSvgY(maxY) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(e, i)}>
                                                         <circle r="8" fill="red" />
                                                         <line x1="-4" y1="-4" x2="4" y2="4" stroke="white" strokeWidth="2" /><line x1="4" y1="-4" x2="-4" y2="4" stroke="white" strokeWidth="2" />
                                                     </g>
@@ -212,7 +212,7 @@ const DesignCanvasRender = ({ viewState, asset, entities, selectedShapeIndices, 
                                                     <rect x={(s.x + s.w / 2) * BASE_SCALE - 5} y={toSvgY(s.y + s.h) * BASE_SCALE - 5} width="10" height="10" fill="lightgreen" stroke="blue" strokeWidth="2" className="cursor-ns-resize" onPointerDown={(e) => onDown(e, i, null, 'vertical')} />
 
                                                     {/* Delete Button (Top-Right + offset) */}
-                                                    <g transform={`translate(${(s.x + s.w) * BASE_SCALE + 10}, ${toSvgY(s.y + s.h) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(i)}>
+                                                    <g transform={`translate(${(s.x + s.w) * BASE_SCALE + 10}, ${toSvgY(s.y + s.h) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(e, i)}>
                                                         <circle r="8" fill="red" />
                                                         <line x1="-4" y1="-4" x2="4" y2="4" stroke="white" strokeWidth="2" /><line x1="4" y1="-4" x2="-4" y2="4" stroke="white" strokeWidth="2" />
                                                     </g>
@@ -432,8 +432,13 @@ export const DesignCanvas = ({ viewState, setViewState, assets, designTargetId, 
      * Updates asset bounds and clears selection.
      * @param {number} index - Index of the shape to delete.
      */
-    const handleDeleteShape = (index) => {
-        if (!confirm('このシェイプを削除しますか？')) return;
+    const handleDeleteShape = (e, index) => {
+        e.stopPropagation();
+        if (!confirm('このシェイプを削除しますか？')) {
+            dragRef.current = { mode: 'idle' };
+            setCursorMode('idle');
+            return;
+        }
         const newEntities = localAsset.entities.filter((_, i) => i !== index);
 
         // Calculate new bounds after deletion


### PR DESCRIPTION
Updates `handleDeleteShape` in `frontend/src/components/DesignCanvas.jsx` to:
1. Accept the event object `e`.
2. Call `e.stopPropagation()` to prevent parent handlers (drag/pan) from firing.
3. Explicitly reset `dragRef.current` and `cursorMode` to `'idle'` when the user cancels the confirmation dialog.
4. Updates JSX to pass the event object to `onDeleteShape`.

This resolves the issue where the cursor would remain in a drag state if the user clicked the delete button but then cancelled the action.

---
*PR created automatically by Jules for task [6201546396693655344](https://jules.google.com/task/6201546396693655344) started by @imohiyoko*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imohiyoko/roomgenerator/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed delete action event handling in the design canvas to ensure proper interface state reset when canceling operations and consistent behavior across delete triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->