### PR TITLE
docs/refactor: create analysis plan and extract domain/canvas logic

### DIFF
--- a/docs/refactoring/ANALYSIS_AND_PLAN.md
+++ b/docs/refactoring/ANALYSIS_AND_PLAN.md
@@ -1,0 +1,83 @@
+# ANALYSIS AND PLAN
+
+## 1. 概要
+`roomGenerator` システムの全体像、コンポーネント構成、データの流れ、状態管理、および主要な関数群を整理し、コントリビュータがシステムを理解しやすくするためのドキュメントです。このドキュメントをもとに、後続のリファクタリング作業を進めます。
+
+## 2. URLとルーティング構造
+
+React Router (HashRouter) を使用してルーティングを行っています。
+
+| URLパス | コンポーネント | 役割 |
+|---|---|---|
+| `/` | `src/pages/Home.jsx` | ホーム画面。プロジェクトの一覧表示と新規作成。 |
+| `/library` | `src/pages/Library.jsx` | グローバルアセット（家具や設備のテンプレート）の管理画面。 |
+| `/project/:id` | `src/pages/Editor.jsx` | エディタ画面。指定されたプロジェクトの編集を行うメイン画面。 |
+| `/settings` | `src/pages/Settings.jsx` | アプリケーションの全体設定（色やグリッドなど）画面。 |
+
+## 3. コンポーネント階層 (Editor画面)
+
+エディタ画面 (`/project/:id`) の主なコンポーネント構成は以下の通りです。
+
+- **`Editor`**: エディタ全体を囲むコンテナ。モードに応じて表示を切り替えます。
+  - **`Header`**: 上部のヘッダー。プロジェクト名や保存状態を表示。
+  - **`UnifiedSidebar`**: 左側のサイドバー。アセットの追加やツールの選択。
+  - **キャンバスエリア**:
+    - **`LayoutCanvas`** (レイアウトモード): 部屋や家具（インスタンス）を配置するキャンバス。
+    - **`DesignCanvas`** (デザインモード): アセットの形状（エンティティ）を直接編集するキャンバス。
+      - `ShapeRenderer`, `HandleRenderer`, `GridRenderer` などのサブコンポーネントを使用。
+  - **プロパティエリア**:
+    - **`LayoutProperties`**: 選択されたインスタンスのプロパティ（位置、回転など）を編集。
+    - **`DesignProperties`**: 選択されたエンティティのプロパティ（サイズ、色、座標など）を編集。
+
+## 4. 状態管理とデータの流れ (Zustand)
+
+状態管理には `Zustand` を使用し、`zundo` ミドルウェアでUndo/Redo機能を提供しています。状態は `src/store/` 配下で管理されています。
+
+### データの保存と読み込みフロー
+1. **読み込み**: `App.jsx` や `Editor.jsx` がマウントされた際、API経由でGoバックエンドからJSONデータを取得し、Zustandのストアにセットします (`projectSlice.js` の `loadProject` など)。
+2. **編集**: ユーザーがキャンバス上で操作を行うと、Zustandのストアが更新されます。
+3. **保存**: ストアの変更を検知して自動保存（`useAutoSave` フック）が行われ、API経由でGoバックエンドにデータが送られ、ローカルのJSONファイルに保存されます。
+
+### 主要な状態 (Slices)
+- **`projectSlice.js`**: プロジェクト全体のメタデータやデフォルトカラー。
+- **`assetSlice.js`**: `localAssets`（プロジェクト固有のアセット）と `globalAssets`。
+- **`instanceSlice.js`**: `instances`（配置されたオブジェクト）。
+- **`uiSlice.js`**: 選択状態（`selectedIds`, `selectedShapeIndices`）やビュー状態（パン、ズーム）。
+
+## 5. 主要な関数とドメインロジック
+
+### 座標系とジオメトリ (`src/domain/geometry.js`)
+キャンバス上の論理座標（Cartesian: Y-Up）と描画座標（SVG: Y-Down）の変換や、バウンディングボックスの計算などを行います。
+- `toSvgY`, `toCartesianY`: Y座標の反転。
+- `rotatePoint`: 点の回転。
+- `getRotatedAABB`: 回転を考慮したバウンディングボックスの計算。
+- `snapValue`: グリッドへのスナップ。
+
+### アセット管理 (`src/domain/assetService.js`)
+アセットやエンティティの作成、更新、複製などのロジックを担当します。
+- `updateAssetEntities(asset, entities)`: アセットのエンティティを更新し、全体の境界（AABB）を再計算します。
+- `forkAsset(asset, defaultColors)`: グローバルアセットをプロジェクト用に複製（フォーク）します。
+
+### プロジェクト読み込み (`src/domain/projectService.js`)
+- `loadProjectData(projectId, api)`: バックエンドからデータを取得し、正規化やマイグレーションを行ってストアに渡す形に整えます。
+
+## 6. バックエンド (Go) とデータ構造
+
+バックエンドは `app.go` に実装され、データ構造は `models.go` に定義されています。
+ローカルの `data/` ディレクトリにJSONファイルとしてデータを保存します。
+
+- **`models.go`**:
+  - `Project`, `Asset`, `Instance`, `Entity` などの構造体。
+  - `Entity` はUnion構造体パターンを使用し、様々な形状（polygon, circle, textなど）に対応します。
+- **`app.go`**:
+  - `GetProjectData`: データの読み込みと、古いフォーマット（例: `shapes` -> `entities`）からのマイグレーションを行います。
+  - `SaveProjectData`: 型安全性を確保するため、JSONを構造体にアンマーシャルして検証してからファイルに保存します。
+
+## 7. 今後のリファクタリング方針
+
+現在の構造は比較的整理されていますが、以下の点を中心に改善を検討します。
+
+1. **コンポーネントの責務分離**: `DesignCanvas.jsx` や `LayoutCanvas.jsx` などの巨大なコンポーネントから、状態管理や複雑な計算ロジック（hooksや外部ヘルパー）をさらに切り離す。
+2. **型安全性の向上 (フロントエンド)**: JSDocやTypeScriptの導入（または強化）により、`Asset`, `Instance`, `Entity` のデータ構造をフロントエンドでも厳密に扱う。
+3. **テストカバレッジの向上**: ドメインロジック（`geometry.js`, `assetService.js`）に対する単体テストを拡充する。
+4. **ドキュメントの最新化**: 本ドキュメント（`ANALYSIS_AND_PLAN.md`）を継続的に更新し、アーキテクチャやワークフローの変更をコントリビュータに分かりやすく伝える。

--- a/frontend/src/components/DesignCanvas.jsx
+++ b/frontend/src/components/DesignCanvas.jsx
@@ -1,15 +1,7 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { BASE_SCALE, SNAP_UNIT } from '../lib/constants';
-import { generateSvgPath, generateEllipsePath, createRectPath, toSvgY, toCartesianY, toSvgRotation, toCartesianRotation, deepClone, calculateAssetBounds, getRotatedAABB } from '../lib/utils';
-import { useStore } from '../store';
-import {
-    initiatePanning, initiateMarquee, initiateResizing, initiateDraggingHandle,
-    initiateDraggingAngle, initiateDraggingRotation, initiateDraggingRadius,
-    initiateDraggingPoint, initiateDraggingShape,
-    processPanning, processMarquee, processResizing, processDraggingShape,
-    processDraggingPoint, processDraggingHandle, processDraggingAngle,
-    processDraggingRotation, processDraggingRadius
-} from './DesignCanvas.logic';
+import React, { useRef, useEffect } from 'react';
+import { BASE_SCALE } from '../lib/constants';
+import { generateSvgPath, generateEllipsePath, createRectPath, toSvgY, toSvgRotation, getRotatedAABB } from '../domain/geometry.js';
+import { useCanvasInteraction } from '../hooks/useCanvasInteraction';
 
 /**
  * Render component for the Design Canvas.
@@ -249,222 +241,22 @@ const DesignCanvasRender = ({ viewState, asset, entities, selectedShapeIndices, 
  * Manages state, event handling, and delegates rendering to DesignCanvasRender.
  */
 export const DesignCanvas = () => {
-    const viewState = useStore(state => state.viewState);
-    const setViewState = useStore(state => state.setViewState);
-    const localAssets = useStore(state => state.localAssets);
-    const setLocalAssets = useStore(state => state.setLocalAssets);
-    const globalAssets = useStore(state => state.globalAssets);
-    const designTargetId = useStore(state => state.designTargetId);
-
-    const selectedShapeIndices = useStore(state => state.selectedShapeIndices);
-    const setSelectedShapeIndices = useStore(state => state.setSelectedShapeIndices);
-    const selectedPointIndex = useStore(state => state.selectedPointIndex);
-    const setSelectedPointIndex = useStore(state => state.setSelectedPointIndex);
-
-    const [localAsset, setLocalAsset] = useState(null);
-    const dragRef = useRef({ mode: 'idle' });
-    const [cursorMode, setCursorMode] = useState('idle');
     const svgRef = useRef(null);
-    const [marquee, setMarquee] = useState(null);
 
-    const assets = [...localAssets, ...globalAssets];
-    const assetFromStore = assets.find(a => a.id === designTargetId);
-
-    const localAssetRef = useRef(null);
-    useEffect(() => {
-        localAssetRef.current = localAsset;
-    }, [localAsset]);
-
-    useEffect(() => {
-        if (assetFromStore && dragRef.current.mode === 'idle') {
-             // Handle entities/shapes structure
-             const normalized = deepClone(assetFromStore);
-             if (!normalized.entities && normalized.shapes) {
-                 normalized.entities = normalized.shapes;
-                 delete normalized.shapes;
-             }
-             setLocalAsset(normalized);
-        }
-    }, [assetFromStore]);
+    const {
+        localAsset,
+        cursorMode,
+        marquee,
+        handleDown,
+        handleMove,
+        handleUp,
+        handleDeleteShape,
+        viewState,
+        selectedShapeIndices,
+        selectedPointIndex
+    } = useCanvasInteraction(svgRef);
 
     if (!localAsset) return null;
-
-    const updateLocalAssetState = (updates) => {
-        const newAsset = { ...localAssetRef.current, ...updates };
-        setLocalAsset(newAsset);
-        localAssetRef.current = newAsset;
-        return newAsset;
-    };
-
-    const updateLocalEntities = (newEntities) => {
-        const updated = { ...localAsset, entities: newEntities, isDefaultShape: false };
-        setLocalAsset(updated);
-        localAssetRef.current = updated;
-    };
-
-    /**
-     * Handles pointer down events on the canvas.
-     * Initiates dragging, resizing, panning, or marquee selection.
-     */
-    const handleDown = (e, shapeIndex = null, pointIndex = null, resizeMode = null, handleIndex = null) => {
-        if (svgRef.current && e.pointerId) svgRef.current.setPointerCapture(e.pointerId);
-        const rect = svgRef.current.getBoundingClientRect();
-
-        // Panning
-        if (e.button === 1) {
-            dragRef.current = initiatePanning(e, viewState, setCursorMode);
-            return;
-        }
-
-        // Marquee
-        if (shapeIndex === null && e.button === 0) {
-            dragRef.current = initiateMarquee(e, setMarquee, setSelectedShapeIndices, selectedShapeIndices);
-            return;
-        }
-
-        const currentEntities = localAsset.entities || [];
-
-        // Resizing
-        if (resizeMode && shapeIndex !== null && currentEntities[shapeIndex]) {
-            dragRef.current = initiateResizing(e, shapeIndex, localAsset, resizeMode, setSelectedShapeIndices, setSelectedPointIndex, setCursorMode);
-            return;
-        }
-
-        // Handle Dragging
-        if (handleIndex !== null && pointIndex !== null && shapeIndex !== null && currentEntities[shapeIndex]) {
-            dragRef.current = initiateDraggingHandle(e, shapeIndex, pointIndex, handleIndex, localAsset, setSelectedShapeIndices, setSelectedPointIndex, setCursorMode);
-            return;
-        }
-
-        // Angle Dragging
-        if ((pointIndex === 'startAngle' || pointIndex === 'endAngle') && shapeIndex !== null && currentEntities[shapeIndex]) {
-            dragRef.current = initiateDraggingAngle(e, shapeIndex, pointIndex, localAsset, viewState, rect, setSelectedShapeIndices, setCursorMode);
-            return;
-        }
-
-        // Rotation Dragging
-        if (pointIndex === 'rotation' && shapeIndex !== null && currentEntities[shapeIndex]) {
-            dragRef.current = initiateDraggingRotation(e, shapeIndex, localAsset, viewState, rect, setSelectedShapeIndices, setCursorMode);
-            return;
-        }
-
-        // Radius Dragging
-        if ((pointIndex === 'rx' || pointIndex === 'ry' || pointIndex === 'rxy') && shapeIndex !== null && currentEntities[shapeIndex]) {
-            dragRef.current = initiateDraggingRadius(e, shapeIndex, pointIndex, localAsset, setSelectedShapeIndices, setCursorMode);
-            return;
-        }
-
-        // Point Dragging
-        if (pointIndex !== null && shapeIndex !== null && currentEntities[shapeIndex]) {
-            dragRef.current = initiateDraggingPoint(e, shapeIndex, pointIndex, localAsset, setSelectedShapeIndices, setSelectedPointIndex, setCursorMode);
-            return;
-        }
-
-        // Shape Dragging
-        if (shapeIndex !== null) {
-            dragRef.current = initiateDraggingShape(e, shapeIndex, localAsset, selectedShapeIndices, setSelectedShapeIndices, setSelectedPointIndex, setCursorMode);
-            return;
-        }
-
-        setSelectedShapeIndices([]);
-        setSelectedPointIndex(null);
-    };
-
-    /**
-     * Handles pointer move events.
-     * Processes ongoing drag/resize operations.
-     */
-    const handleMove = (e) => {
-        const mode = dragRef.current.mode;
-        if (mode === 'idle') return;
-        e.preventDefault();
-
-        if (mode === 'panning') {
-            processPanning(e, dragRef.current, setViewState);
-            return;
-        }
-
-        if (mode === 'marquee') {
-            processMarquee(e, dragRef.current, setMarquee, svgRef, viewState, localAsset, setSelectedShapeIndices);
-            return;
-        }
-
-        let newEntities = null;
-
-        if (mode === 'resizing' && selectedShapeIndices.length > 0) {
-            newEntities = processResizing(e, dragRef.current, localAsset, viewState, selectedShapeIndices);
-        } else if (mode === 'draggingShape') {
-            newEntities = processDraggingShape(e, dragRef.current, localAsset, viewState);
-        } else if (mode === 'draggingPoint' && selectedShapeIndices.length > 0 && selectedPointIndex !== null) {
-            newEntities = processDraggingPoint(e, dragRef.current, localAsset, viewState, selectedShapeIndices, selectedPointIndex);
-        } else if (mode === 'draggingHandle' && selectedShapeIndices.length > 0 && selectedPointIndex !== null) {
-            newEntities = processDraggingHandle(e, dragRef.current, localAsset, viewState, selectedShapeIndices, selectedPointIndex);
-        } else if (mode === 'draggingAngle' && selectedShapeIndices.length > 0) {
-            newEntities = processDraggingAngle(e, dragRef.current, localAsset, selectedShapeIndices);
-        } else if (mode === 'draggingRotation' && selectedShapeIndices.length > 0) {
-            newEntities = processDraggingRotation(e, dragRef.current, localAsset, selectedShapeIndices);
-        } else if (mode === 'draggingRadius' && selectedShapeIndices.length > 0) {
-            newEntities = processDraggingRadius(e, dragRef.current, localAsset, viewState, selectedShapeIndices);
-        }
-
-        if (newEntities) {
-            updateLocalEntities(newEntities);
-        }
-    };
-
-    /**
-     * Handles pointer up events.
-     * Finalizes drag operations and updates global state (undo history).
-     */
-    const handleUp = () => {
-        setMarquee(null);
-        setCursorMode('idle');
-
-        if (dragRef.current.mode !== 'idle' && dragRef.current.mode !== 'marquee' && dragRef.current.mode !== 'panning') {
-            const currentAsset = localAssetRef.current;
-            const entities = currentAsset.entities || [];
-            const bounds = calculateAssetBounds(entities);
-
-            let updates = {};
-            if (bounds) {
-                if (currentAsset.w !== bounds.w || currentAsset.h !== bounds.h || currentAsset.boundX !== bounds.boundX || currentAsset.boundY !== bounds.boundY) {
-                    updates = bounds;
-                }
-            }
-
-            const newAsset = updateLocalAssetState(updates);
-            setLocalAssets(prev => prev.map(a => a.id === designTargetId ? newAsset : a));
-        }
-        dragRef.current = { mode: 'idle' };
-    };
-
-    /**
-     * Deletes a shape at the specified index.
-     * Updates asset bounds and clears selection.
-     * @param {number} index - Index of the shape to delete.
-     */
-    const handleDeleteShape = (e, index) => {
-        e.stopPropagation();
-        if (!confirm('このシェイプを削除しますか？')) {
-            dragRef.current = { mode: 'idle' };
-            setCursorMode('idle');
-            return;
-        }
-        const newEntities = localAsset.entities.filter((_, i) => i !== index);
-
-        // Calculate new bounds after deletion
-        const bounds = calculateAssetBounds(newEntities);
-        const updates = {
-            entities: newEntities,
-            isDefaultShape: false,
-            ...(bounds || {})
-        };
-
-        const newAsset = updateLocalAssetState(updates);
-        setLocalAssets(prev => prev.map(a => a.id === designTargetId ? newAsset : a));
-        setSelectedShapeIndices([]);
-        setSelectedPointIndex(null);
-    };
 
     const entities = (localAsset && localAsset.entities && localAsset.entities.length > 0)
         ? localAsset.entities

--- a/frontend/src/components/DesignCanvas.logic.js
+++ b/frontend/src/components/DesignCanvas.logic.js
@@ -1,4 +1,5 @@
-import { deepClone, toSvgY, toCartesianY, toCartesianRotation } from '../lib/utils';
+import { deepClone } from '../lib/utils.js';
+import { toSvgY, toCartesianY, toCartesianRotation } from '../domain/geometry.js';
 import { BASE_SCALE, SNAP_UNIT } from '../lib/constants';
 
 /**

--- a/frontend/src/components/DesignProperties.jsx
+++ b/frontend/src/components/DesignProperties.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Icon, Icons } from './Icon';
 import { ColorPicker } from './ColorPicker';
 import { NumberInput } from './NumberInput';
-import { fromMM, toMM, createRectPath, createTrianglePath, deepClone, calculateAssetBounds } from '../lib/utils';
+import { fromMM, toMM, deepClone } from '../lib/utils.js';
+import { createRectPath, createTrianglePath, calculateAssetBounds } from '../domain/geometry.js';
 import { updateAssetEntities } from '../domain/assetService';
 import { useStore } from '../store';
 

--- a/frontend/src/components/LayoutCanvas.jsx
+++ b/frontend/src/components/LayoutCanvas.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useMemo, useEffect } from 'react';
 import { BASE_SCALE, SNAP_UNIT, LAYERS } from '../lib/constants';
-import { toMM, toSvgY, toCartesianY, toSvgRotation } from '../lib/utils';
+import { toMM } from '../lib/utils.js';
+import { toSvgY, toCartesianY, toSvgRotation } from '../domain/geometry.js';
 import { RenderAssetShapes } from './SharedRender';
 import { useStore } from '../store';
 

--- a/frontend/src/components/SharedRender.jsx
+++ b/frontend/src/components/SharedRender.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BASE_SCALE } from '../lib/constants';
-import { generateEllipsePath, generateSvgPath, createRectPath, toSvgY, toSvgRotation } from '../lib/utils';
+import { generateEllipsePath, generateSvgPath, createRectPath, toSvgY, toSvgRotation } from '../domain/geometry.js';
 
 export const RenderAssetShapes = ({ item, isSelected }) => {
     // Fallback for migration

--- a/frontend/src/components/UnifiedSidebar.jsx
+++ b/frontend/src/components/UnifiedSidebar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useStore } from '../store';
 import { Icon, Icons } from './Icon';
-import { createRectPath } from '../lib/utils';
+import { createRectPath } from '../domain/geometry.js';
 
 export const UnifiedSidebar = ({ mode, assets, onAddInstance, onAddText, setLocalAssets, setGlobalAssets, setDesignTargetId, designTargetId, instances, setInstances, defaultColors }) => {
     const categoryLabels = useStore(state => state.categoryLabels);

--- a/frontend/src/domain/assetService.js
+++ b/frontend/src/domain/assetService.js
@@ -1,9 +1,80 @@
-import { deepClone, calculateAssetBounds } from '../lib/utils.js';
+import { deepClone } from '../lib/utils.js';
+import { calculateAssetBounds } from '../domain/geometry.js';
 import { BASE_SCALE } from '../lib/constants.js';
+
+/**
+ * @typedef {Object} Point
+ * @property {number} x
+ * @property {number} y
+ * @property {Object} [h1] - Handle 1 for Bezier curves {x,y}
+ * @property {Object} [h2] - Handle 2 for Bezier curves {x,y}
+ * @property {boolean} [isCurve]
+ * @property {Array<{x:number, y:number}>} [handles] - Specific handles for multi-segment curves
+ */
+
+/**
+ * @typedef {Object} Entity
+ * @property {string} type - 'polygon', 'circle', 'ellipse', 'arc', 'text', 'rect'
+ * @property {string} [layer='0']
+ * @property {string} [color]
+ * @property {number} [x]
+ * @property {number} [y]
+ * @property {number} [w]
+ * @property {number} [h]
+ * @property {Array<Point>} [points] - For 'polygon' type
+ * @property {number} [cx] - For 'circle'/'ellipse'/'arc'
+ * @property {number} [cy]
+ * @property {number} [rx]
+ * @property {number} [ry]
+ * @property {number} [startAngle] - For arcs
+ * @property {number} [endAngle]
+ * @property {string} [arcMode] - 'sector' or 'chord'
+ * @property {number} [rotation] - Rotation in degrees (Cartesian CCW)
+ * @property {string} [text] - For 'text' type
+ * @property {number} [fontSize]
+ */
+
+/**
+ * @typedef {Object} Asset
+ * @property {string} id
+ * @property {string} name
+ * @property {string} type - 'room', 'furniture', 'fixture'
+ * @property {number} w - Width (Cartesian)
+ * @property {number} h - Height (Cartesian)
+ * @property {number} [boundX] - Min X of AABB
+ * @property {number} [boundY] - Min Y of AABB
+ * @property {string} color
+ * @property {boolean} [isDefaultShape]
+ * @property {boolean} [snap]
+ * @property {Array<Entity>} entities
+ * @property {string} [source] - 'global' or undefined
+ */
+
+/**
+ * @typedef {Object} Instance
+ * @property {string} id
+ * @property {string} [assetId] - Reference to localAssets (undefined for 'text')
+ * @property {string} type - 'text' or asset.type
+ * @property {number} x
+ * @property {number} y
+ * @property {number} rotation
+ * @property {boolean} locked
+ * @property {string} [text]
+ * @property {number} [fontSize]
+ * @property {string} [color]
+ */
 
 // --- Logic from store.js ---
 
-// Updates an asset with new entities and recalculates its bounding box.
+/**
+ * Updates an asset with new entities and recalculates its bounding box.
+ * This ensures that any modification to entities (add, remove, edit)
+ * correctly updates the asset's overall dimensions and origin.
+ *
+ * @param {Asset} asset - The original asset
+ * @param {Array<Entity>} newEntities - The updated entities array
+ * @returns {Asset|null} The updated asset with recalculated bounds
+ */
 // This ensures that any modification to entities (add, remove, edit)
 // correctly updates the asset's overall dimensions and origin.
 export const updateAssetEntities = (asset, newEntities) => {

--- a/frontend/src/domain/geometry.js
+++ b/frontend/src/domain/geometry.js
@@ -1,0 +1,307 @@
+import { BASE_SCALE } from '../lib/constants.js';
+
+/**
+ * @typedef {import('./assetService').Entity} Entity
+ */
+
+// Coordinate System Conversion (Cartesian Y-Up <-> SVG Y-Down)
+// SVG Origin is Top-Left (Y increases Down). Cartesian Origin is Bottom-Left (Y increases Up).
+// For rendering, we map Cartesian Y to SVG Y by flipping the sign.
+export const toSvgY = (y) => -y;
+export const toCartesianY = (y) => -y;
+export const toSvgRotation = (deg) => -deg;
+export const toCartesianRotation = (deg) => -deg;
+export const toSvgAngle = (deg) => -deg;
+export const toCartesianAngle = (deg) => -deg;
+
+export const createRectPath = (w, h, x = 0, y = 0) => [
+    { x: x, y: y, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },
+    { x: x + w, y: y, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },
+    { x: x + w, y: y + h, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },
+    { x: x, y: y + h, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },
+];
+
+export const createTrianglePath = (w, h, x = 0, y = 0) => [
+    { x: x + w / 2, y: y + h, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false }, // Top vertex
+    { x: x + w, y: y, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },     // Bottom Right
+    { x: x, y: y, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },         // Bottom Left
+];
+
+// SVG Path Generation with Cartesian -> SVG Coordinate Conversion
+// Handles flipping Y axis
+export const generateSvgPath = (points) => {
+    if (!points || points.length === 0) return "";
+
+    const tx = (x) => x * BASE_SCALE;
+    const ty = (y) => toSvgY(y) * BASE_SCALE;
+
+    let d = `M ${tx(points[0].x)} ${ty(points[0].y)}`;
+    for (let i = 0; i < points.length; i++) {
+        const curr = points[i];
+        const next = points[(i + 1) % points.length];
+        const handles = curr.handles || [];
+
+        if (handles.length === 0) {
+            if (curr.isCurve || next.isCurve) {
+                // Legacy curve support
+                const cp1x = tx(curr.x + (curr.h2?.x || 0));
+                const cp1y = ty(curr.y + (curr.h2?.y || 0));
+                const cp2x = tx(next.x + (next.h1?.x || 0));
+                const cp2y = ty(next.y + (next.h1?.y || 0));
+                d += ` C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${tx(next.x)} ${ty(next.y)}`;
+            } else {
+                d += ` L ${tx(next.x)} ${ty(next.y)}`;
+            }
+        } else if (handles.length === 1) {
+            const h = handles[0];
+            d += ` Q ${tx(h.x)} ${ty(h.y)}, ${tx(next.x)} ${ty(next.y)}`;
+        } else if (handles.length === 2) {
+            const h1 = handles[0];
+            const h2 = handles[1];
+            d += ` C ${tx(h1.x)} ${ty(h1.y)}, ${tx(h2.x)} ${ty(h2.y)}, ${tx(next.x)} ${ty(next.y)}`;
+        } else {
+            const step = 1 / handles.length;
+            let lastX = curr.x, lastY = curr.y;
+            for (let j = 0; j < handles.length; j++) {
+                const h = handles[j];
+                const t = (j + 1) * step;
+                const endX = curr.x + (next.x - curr.x) * t;
+                const endY = curr.y + (next.y - curr.y) * t;
+                d += ` Q ${tx(h.x)} ${ty(h.y)}, ${tx(endX)} ${ty(endY)}`;
+                lastX = endX; lastY = endY;
+            }
+            if (Math.abs(lastX - next.x) > 0.01 || Math.abs(lastY - next.y) > 0.01) {
+                d += ` L ${tx(next.x)} ${ty(next.y)}`;
+            }
+        }
+    }
+    d += " Z";
+    return d;
+};
+
+// Generate Ellipse/Arc Path with Cartesian -> SVG Conversion
+export const generateEllipsePath = (shape) => {
+    // Cartesian inputs
+    const { cx = 0, cy = 0, rx = 50, ry = 50, startAngle = 0, endAngle = 360, arcMode = 'sector', rotation = 0 } = shape;
+
+    // Convert to SVG coordinates
+    const cxs = cx * BASE_SCALE;
+    const cys = toSvgY(cy) * BASE_SCALE;
+    const rxs = rx * BASE_SCALE;
+    const rys = ry * BASE_SCALE;
+
+    const svgStartAngle = -startAngle;
+    const svgEndAngle = -endAngle;
+
+    const startRadSvg = (svgStartAngle * Math.PI) / 180;
+    const endRadSvg = (svgEndAngle * Math.PI) / 180;
+
+    const x1 = cxs + rxs * Math.cos(startRadSvg);
+    const y1 = cys + rys * Math.sin(startRadSvg);
+    const x2 = cxs + rxs * Math.cos(endRadSvg);
+    const y2 = cys + rys * Math.sin(endRadSvg);
+
+    // Full ellipse check
+    const angleDiff = Math.abs(endAngle - startAngle); // Absolute difference in degrees
+    if (angleDiff >= 360) {
+        return `M ${cxs - rxs} ${cys} A ${rxs} ${rys} 0 1 1 ${cxs + rxs} ${cys} A ${rxs} ${rys} 0 1 1 ${cxs - rxs} ${cys}`;
+    }
+
+    const largeArc = angleDiff > 180 ? 1 : 0;
+    const sweepFlag = 0; // CCW for Cartesian positive angle direction
+
+    if (arcMode === 'sector') {
+        return `M ${cxs} ${cys} L ${x1} ${y1} A ${rxs} ${rys} 0 ${largeArc} ${sweepFlag} ${x2} ${y2} Z`;
+    } else {
+        return `M ${x1} ${y1} A ${rxs} ${rys} 0 ${largeArc} ${sweepFlag} ${x2} ${y2} Z`;
+    }
+};
+
+// Helper to rotate a point (px, py) around (cx, cy) by angle (degrees)
+export const rotatePoint = (px, py, cx, cy, angle) => {
+    const rad = (angle * Math.PI) / 180;
+    const cos = Math.cos(rad);
+    const sin = Math.sin(rad);
+    const dx = px - cx;
+    const dy = py - cy;
+    return {
+        x: cx + dx * cos - dy * sin,
+        y: cy + dx * sin + dy * cos
+    };
+};
+
+export const getRotatedAABB = (shape) => {
+    if (!shape) return null;
+
+    // Handle Ellipse / Circle / Arc / Sector
+    if (shape.type === 'ellipse' || shape.type === 'circle' || shape.type === 'arc') {
+        const cx = shape.cx !== undefined ? shape.cx : (shape.x + shape.w / 2);
+        const cy = shape.cy !== undefined ? shape.cy : (shape.y + shape.h / 2);
+        const rx = shape.rx !== undefined ? shape.rx : (shape.w / 2);
+        const ry = shape.ry !== undefined ? shape.ry : (shape.h / 2);
+        const rotation = shape.rotation || 0;
+        const startAngle = shape.startAngle !== undefined ? shape.startAngle : 0;
+        const endAngle = shape.endAngle !== undefined ? shape.endAngle : 360;
+        const isSector = shape.arcMode === 'sector' || (shape.type === 'circle' && shape.arcMode !== 'chord');
+
+        const rotRad = (rotation * Math.PI) / 180;
+        const cosRot = Math.cos(rotRad);
+        const sinRot = Math.sin(rotRad);
+
+        const getPoint = (tDeg) => {
+            const tRad = (tDeg * Math.PI) / 180;
+            const x0 = rx * Math.cos(tRad);
+            const y0 = ry * Math.sin(tRad);
+            const xRot = x0 * cosRot - y0 * sinRot;
+            const yRot = x0 * sinRot + y0 * cosRot;
+            return { x: cx + xRot, y: cy + yRot };
+        };
+
+        let pointsToCheck = [];
+
+        pointsToCheck.push(getPoint(startAngle));
+        pointsToCheck.push(getPoint(endAngle));
+
+        if (isSector) {
+             pointsToCheck.push({ x: cx, y: cy });
+        }
+
+        const calcExtremaAngles = (isX) => {
+            let t = [];
+            if (isX) {
+                if (Math.abs(cosRot) < 1e-9) {
+                     t.push(90, 270);
+                } else {
+                    const val = -(ry * sinRot) / (rx * cosRot);
+                    const angle1 = Math.atan(val) * 180 / Math.PI;
+                    t.push(angle1, angle1 + 180);
+                }
+            } else {
+                if (Math.abs(sinRot) < 1e-9) {
+                    t.push(90, 270);
+                } else {
+                    const val = (ry * cosRot) / (rx * sinRot);
+                    const angle1 = Math.atan(val) * 180 / Math.PI;
+                    t.push(angle1, angle1 + 180);
+                }
+            }
+            return t.map(a => (a + 360) % 360);
+        };
+
+        const xExtrema = calcExtremaAngles(true);
+        const yExtrema = calcExtremaAngles(false);
+        const allExtrema = [...xExtrema, ...yExtrema];
+
+        let start = startAngle;
+        let end = endAngle;
+
+        const isAngleInArc = (angle) => {
+             const a = (angle % 360 + 360) % 360;
+             const s = (start % 360 + 360) % 360;
+             const e = (end % 360 + 360) % 360;
+             if (s <= e) {
+                 return a >= s && a <= e;
+             } else {
+                 return a >= s || a <= e;
+             }
+        };
+
+        const sweep = Math.abs(end - start);
+        if (sweep >= 360) {
+            allExtrema.forEach((t) => {
+                pointsToCheck.push(getPoint(t));
+            });
+        } else {
+            allExtrema.forEach(t => {
+                if (isAngleInArc(t)) {
+                    pointsToCheck.push(getPoint(t));
+                }
+            });
+        }
+
+        if (pointsToCheck.length === 0) return null;
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        pointsToCheck.forEach(p => {
+            if (p.x < minX) minX = p.x;
+            if (p.x > maxX) maxX = p.x;
+            if (p.y < minY) minY = p.y;
+            if (p.y > maxY) maxY = p.y;
+        });
+
+        return { minX, minY, maxX, maxY };
+    }
+
+    if (shape.points && shape.points.length > 0) {
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        shape.points.forEach(p => {
+            if (p.x < minX) minX = p.x; if (p.x > maxX) maxX = p.x;
+            if (p.y < minY) minY = p.y; if (p.y > maxY) maxY = p.y;
+        });
+        const cx = minX + (maxX - minX) / 2;
+        const cy = minY + (maxY - minY) / 2;
+
+        const rotation = shape.rotation || 0;
+
+        let rPoints = [];
+        if (rotation === 0) {
+            rPoints = shape.points;
+        } else {
+            rPoints = shape.points.map(p => rotatePoint(p.x, p.y, cx, cy, rotation));
+        }
+
+        let rMinX = Infinity, rMinY = Infinity, rMaxX = -Infinity, rMaxY = -Infinity;
+        rPoints.forEach(p => {
+            if (p.x < rMinX) rMinX = p.x; if (p.x > rMaxX) rMaxX = p.x;
+            if (p.y < rMinY) rMinY = p.y; if (p.y > rMaxY) rMaxY = p.y;
+        });
+        return { minX: rMinX, minY: rMinY, maxX: rMaxX, maxY: rMaxY };
+    }
+
+    if (shape.x !== undefined && shape.w !== undefined) {
+        const cx = shape.x + shape.w / 2;
+        const cy = shape.y + shape.h / 2;
+        const rotation = shape.rotation || 0;
+        const pts = [
+            { x: shape.x, y: shape.y },
+            { x: shape.x + shape.w, y: shape.y },
+            { x: shape.x + shape.w, y: shape.y + shape.h },
+            { x: shape.x, y: shape.y + shape.h }
+        ];
+        const rPoints = pts.map(p => rotatePoint(p.x, p.y, cx, cy, rotation));
+        let rMinX = Infinity, rMinY = Infinity, rMaxX = -Infinity, rMaxY = -Infinity;
+        rPoints.forEach(p => {
+            if (p.x < rMinX) rMinX = p.x; if (p.x > rMaxX) rMaxX = p.x;
+            if (p.y < rMinY) rMinY = p.y; if (p.y > rMaxY) rMaxY = p.y;
+        });
+        return { minX: rMinX, minY: rMinY, maxX: rMaxX, maxY: rMaxY };
+    }
+
+    return null;
+};
+
+export const calculateAssetBounds = (entities) => {
+    if (!entities || entities.length === 0) return null;
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    let hasValid = false;
+
+    entities.forEach(s => {
+        const box = getRotatedAABB(s);
+        if (box) {
+            hasValid = true;
+            if (box.minX < minX) minX = box.minX;
+            if (box.maxX > maxX) maxX = box.maxX;
+            if (box.minY < minY) minY = box.minY;
+            if (box.maxY > maxY) maxY = box.maxY;
+        }
+    });
+
+    if (hasValid && minX !== Infinity) {
+        return {
+            boundX: Math.round(minX),
+            boundY: Math.round(minY),
+            w: Math.round(maxX - minX),
+            h: Math.round(maxY - minY)
+        };
+    }
+    return null;
+};

--- a/frontend/src/hooks/useCanvasInteraction.js
+++ b/frontend/src/hooks/useCanvasInteraction.js
@@ -1,0 +1,215 @@
+import { useState, useRef, useEffect } from 'react';
+import { useStore } from '../store';
+import { deepClone } from '../lib/utils';
+import { calculateAssetBounds } from '../domain/geometry';
+import {
+    initiatePanning, initiateMarquee, initiateResizing, initiateDraggingHandle,
+    initiateDraggingAngle, initiateDraggingRotation, initiateDraggingRadius,
+    initiateDraggingPoint, initiateDraggingShape,
+    processPanning, processMarquee, processResizing, processDraggingShape,
+    processDraggingPoint, processDraggingHandle, processDraggingAngle,
+    processDraggingRotation, processDraggingRadius
+} from '../components/DesignCanvas.logic';
+
+export const useCanvasInteraction = (svgRef) => {
+    const viewState = useStore(state => state.viewState);
+    const setViewState = useStore(state => state.setViewState);
+    const localAssets = useStore(state => state.localAssets);
+    const setLocalAssets = useStore(state => state.setLocalAssets);
+    const globalAssets = useStore(state => state.globalAssets);
+    const designTargetId = useStore(state => state.designTargetId);
+
+    const selectedShapeIndices = useStore(state => state.selectedShapeIndices);
+    const setSelectedShapeIndices = useStore(state => state.setSelectedShapeIndices);
+    const selectedPointIndex = useStore(state => state.selectedPointIndex);
+    const setSelectedPointIndex = useStore(state => state.setSelectedPointIndex);
+
+    const [localAsset, setLocalAsset] = useState(null);
+    const dragRef = useRef({ mode: 'idle' });
+    const [cursorMode, setCursorMode] = useState('idle');
+    const [marquee, setMarquee] = useState(null);
+
+    const assets = [...localAssets, ...globalAssets];
+    const assetFromStore = assets.find(a => a.id === designTargetId);
+
+    const localAssetRef = useRef(null);
+    useEffect(() => {
+        localAssetRef.current = localAsset;
+    }, [localAsset]);
+
+    useEffect(() => {
+        if (assetFromStore && dragRef.current.mode === 'idle') {
+             const normalized = deepClone(assetFromStore);
+             if (!normalized.entities && normalized.shapes) {
+                 normalized.entities = normalized.shapes;
+                 delete normalized.shapes;
+             }
+             setLocalAsset(normalized);
+        }
+    }, [assetFromStore]);
+
+    const updateLocalAssetState = (updates) => {
+        const newAsset = { ...localAssetRef.current, ...updates };
+        setLocalAsset(newAsset);
+        localAssetRef.current = newAsset;
+        return newAsset;
+    };
+
+    const updateLocalEntities = (newEntities) => {
+        const updated = { ...localAssetRef.current, entities: newEntities, isDefaultShape: false };
+        setLocalAsset(updated);
+        localAssetRef.current = updated;
+    };
+
+    const handleDown = (e, shapeIndex = null, pointIndex = null, resizeMode = null, handleIndex = null) => {
+        if (svgRef.current && e.pointerId) svgRef.current.setPointerCapture(e.pointerId);
+        const rect = svgRef.current ? svgRef.current.getBoundingClientRect() : { left: 0, top: 0 };
+
+        if (e.button === 1) {
+            dragRef.current = initiatePanning(e, viewState, setCursorMode);
+            return;
+        }
+
+        if (shapeIndex === null && e.button === 0) {
+            dragRef.current = initiateMarquee(e, setMarquee, setSelectedShapeIndices, selectedShapeIndices);
+            return;
+        }
+
+        const currentEntities = localAssetRef.current?.entities || [];
+
+        if (resizeMode && shapeIndex !== null && currentEntities[shapeIndex]) {
+            dragRef.current = initiateResizing(e, shapeIndex, localAssetRef.current, resizeMode, setSelectedShapeIndices, setSelectedPointIndex, setCursorMode);
+            return;
+        }
+
+        if (handleIndex !== null && pointIndex !== null && shapeIndex !== null && currentEntities[shapeIndex]) {
+            dragRef.current = initiateDraggingHandle(e, shapeIndex, pointIndex, handleIndex, localAssetRef.current, setSelectedShapeIndices, setSelectedPointIndex, setCursorMode);
+            return;
+        }
+
+        if ((pointIndex === 'startAngle' || pointIndex === 'endAngle') && shapeIndex !== null && currentEntities[shapeIndex]) {
+            dragRef.current = initiateDraggingAngle(e, shapeIndex, pointIndex, localAssetRef.current, viewState, rect, setSelectedShapeIndices, setCursorMode);
+            return;
+        }
+
+        if (pointIndex === 'rotation' && shapeIndex !== null && currentEntities[shapeIndex]) {
+            dragRef.current = initiateDraggingRotation(e, shapeIndex, localAssetRef.current, viewState, rect, setSelectedShapeIndices, setCursorMode);
+            return;
+        }
+
+        if ((pointIndex === 'rx' || pointIndex === 'ry' || pointIndex === 'rxy') && shapeIndex !== null && currentEntities[shapeIndex]) {
+            dragRef.current = initiateDraggingRadius(e, shapeIndex, pointIndex, localAssetRef.current, setSelectedShapeIndices, setCursorMode);
+            return;
+        }
+
+        if (pointIndex !== null && shapeIndex !== null && currentEntities[shapeIndex]) {
+            dragRef.current = initiateDraggingPoint(e, shapeIndex, pointIndex, localAssetRef.current, setSelectedShapeIndices, setSelectedPointIndex, setCursorMode);
+            return;
+        }
+
+        if (shapeIndex !== null) {
+            dragRef.current = initiateDraggingShape(e, shapeIndex, localAssetRef.current, selectedShapeIndices, setSelectedShapeIndices, setSelectedPointIndex, setCursorMode);
+            return;
+        }
+
+        setSelectedShapeIndices([]);
+        setSelectedPointIndex(null);
+    };
+
+    const handleMove = (e) => {
+        const mode = dragRef.current.mode;
+        if (mode === 'idle') return;
+        e.preventDefault();
+
+        if (mode === 'panning') {
+            processPanning(e, dragRef.current, setViewState);
+            return;
+        }
+
+        if (mode === 'marquee') {
+            processMarquee(e, dragRef.current, setMarquee, svgRef, viewState, localAssetRef.current, setSelectedShapeIndices);
+            return;
+        }
+
+        let newEntities = null;
+
+        if (mode === 'resizing' && selectedShapeIndices.length > 0) {
+            newEntities = processResizing(e, dragRef.current, localAssetRef.current, viewState, selectedShapeIndices);
+        } else if (mode === 'draggingShape') {
+            newEntities = processDraggingShape(e, dragRef.current, localAssetRef.current, viewState);
+        } else if (mode === 'draggingPoint' && selectedShapeIndices.length > 0 && selectedPointIndex !== null) {
+            newEntities = processDraggingPoint(e, dragRef.current, localAssetRef.current, viewState, selectedShapeIndices, selectedPointIndex);
+        } else if (mode === 'draggingHandle' && selectedShapeIndices.length > 0 && selectedPointIndex !== null) {
+            newEntities = processDraggingHandle(e, dragRef.current, localAssetRef.current, viewState, selectedShapeIndices, selectedPointIndex);
+        } else if (mode === 'draggingAngle' && selectedShapeIndices.length > 0) {
+            newEntities = processDraggingAngle(e, dragRef.current, localAssetRef.current, selectedShapeIndices);
+        } else if (mode === 'draggingRotation' && selectedShapeIndices.length > 0) {
+            newEntities = processDraggingRotation(e, dragRef.current, localAssetRef.current, selectedShapeIndices);
+        } else if (mode === 'draggingRadius' && selectedShapeIndices.length > 0) {
+            newEntities = processDraggingRadius(e, dragRef.current, localAssetRef.current, viewState, selectedShapeIndices);
+        }
+
+        if (newEntities) {
+            updateLocalEntities(newEntities);
+        }
+    };
+
+    const handleUp = () => {
+        setMarquee(null);
+        setCursorMode('idle');
+
+        if (dragRef.current.mode !== 'idle' && dragRef.current.mode !== 'marquee' && dragRef.current.mode !== 'panning') {
+            const currentAsset = localAssetRef.current;
+            const entities = currentAsset.entities || [];
+            const bounds = calculateAssetBounds(entities);
+
+            let updates = {};
+            if (bounds) {
+                if (currentAsset.w !== bounds.w || currentAsset.h !== bounds.h || currentAsset.boundX !== bounds.boundX || currentAsset.boundY !== bounds.boundY) {
+                    updates = bounds;
+                }
+            }
+
+            const newAsset = updateLocalAssetState(updates);
+            setLocalAssets(prev => prev.map(a => a.id === designTargetId ? newAsset : a));
+        }
+        dragRef.current = { mode: 'idle' };
+    };
+
+    const handleDeleteShape = (e, index) => {
+        e.stopPropagation();
+        if (!confirm('このシェイプを削除しますか？')) {
+            dragRef.current = { mode: 'idle' };
+            setCursorMode('idle');
+            return;
+        }
+
+        const currentEntities = localAssetRef.current.entities || [];
+        const newEntities = currentEntities.filter((_, i) => i !== index);
+
+        const bounds = calculateAssetBounds(newEntities);
+        const updates = {
+            entities: newEntities,
+            isDefaultShape: false,
+            ...(bounds || {})
+        };
+
+        const newAsset = updateLocalAssetState(updates);
+        setLocalAssets(prev => prev.map(a => a.id === designTargetId ? newAsset : a));
+        setSelectedShapeIndices([]);
+        setSelectedPointIndex(null);
+    };
+
+    return {
+        localAsset,
+        cursorMode,
+        marquee,
+        handleDown,
+        handleMove,
+        handleUp,
+        handleDeleteShape,
+        viewState,
+        selectedShapeIndices,
+        selectedPointIndex
+    };
+};

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -7,30 +7,27 @@ export const fromMM = (val) => val / 10;
 // SVG Origin is Top-Left (Y increases Down). Cartesian Origin is Bottom-Left (Y increases Up).
 // For rendering, we map Cartesian Y to SVG Y by flipping the sign.
 // Note: This assumes a relative transformation or centering is applied elsewhere (e.g. viewState translation).
-export const toSvgY = (y) => -y;
-export const toCartesianY = (y) => -y;
-export const toSvgRotation = (deg) => -deg;
-export const toCartesianRotation = (deg) => -deg;
-export const toSvgAngle = (deg) => -deg;
-export const toCartesianAngle = (deg) => -deg;
+// Re-export geometry functions for backwards compatibility
+export {
+    toSvgY,
+    toCartesianY,
+    toSvgRotation,
+    toCartesianRotation,
+    toSvgAngle,
+    toCartesianAngle,
+    createRectPath,
+    createTrianglePath,
+    generateSvgPath,
+    generateEllipsePath,
+    rotatePoint,
+    getRotatedAABB,
+    calculateAssetBounds
+} from '../domain/geometry.js';
 
 export const deepClone = (obj) => {
     if (obj === null || typeof obj !== 'object') return obj;
     return JSON.parse(JSON.stringify(obj));
 };
-
-export const createRectPath = (w, h, x = 0, y = 0) => [
-    { x: x, y: y, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },
-    { x: x + w, y: y, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },
-    { x: x + w, y: y + h, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },
-    { x: x, y: y + h, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },
-];
-
-export const createTrianglePath = (w, h, x = 0, y = 0) => [
-    { x: x + w / 2, y: y + h, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false }, // Top vertex
-    { x: x + w, y: y, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },     // Bottom Right
-    { x: x, y: y, h1: { x: 0, y: 0 }, h2: { x: 0, y: 0 }, isCurve: false },         // Bottom Left
-];
 
 export const normalizeAsset = (asset) => {
     if (!asset) return null;
@@ -50,346 +47,15 @@ export const normalizeAsset = (asset) => {
     return { ...asset, entities, shapes: undefined, w: asset.w || 60, h: asset.h || 60 };
 };
 
-// SVG Path Generation with Cartesian -> SVG Coordinate Conversion
-// Handles flipping Y axis
-export const generateSvgPath = (points) => {
-    if (!points || points.length === 0) return "";
-
-    const tx = (x) => x * BASE_SCALE;
-    const ty = (y) => toSvgY(y) * BASE_SCALE;
-
-    let d = `M ${tx(points[0].x)} ${ty(points[0].y)}`;
-    for (let i = 0; i < points.length; i++) {
-        const curr = points[i];
-        const next = points[(i + 1) % points.length];
-        const handles = curr.handles || [];
-
-        if (handles.length === 0) {
-            if (curr.isCurve || next.isCurve) {
-                // Legacy curve support
-                const cp1x = tx(curr.x + (curr.h2?.x || 0));
-                const cp1y = ty(curr.y + (curr.h2?.y || 0));
-                const cp2x = tx(next.x + (next.h1?.x || 0));
-                const cp2y = ty(next.y + (next.h1?.y || 0));
-                d += ` C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${tx(next.x)} ${ty(next.y)}`;
-            } else {
-                d += ` L ${tx(next.x)} ${ty(next.y)}`;
-            }
-        } else if (handles.length === 1) {
-            const h = handles[0];
-            d += ` Q ${tx(h.x)} ${ty(h.y)}, ${tx(next.x)} ${ty(next.y)}`;
-        } else if (handles.length === 2) {
-            const h1 = handles[0];
-            const h2 = handles[1];
-            d += ` C ${tx(h1.x)} ${ty(h1.y)}, ${tx(h2.x)} ${ty(h2.y)}, ${tx(next.x)} ${ty(next.y)}`;
-        } else {
-            const step = 1 / handles.length;
-            let lastX = curr.x, lastY = curr.y;
-            for (let j = 0; j < handles.length; j++) {
-                const h = handles[j];
-                const t = (j + 1) * step;
-                const endX = curr.x + (next.x - curr.x) * t;
-                const endY = curr.y + (next.y - curr.y) * t;
-                d += ` Q ${tx(h.x)} ${ty(h.y)}, ${tx(endX)} ${ty(endY)}`;
-                lastX = endX; lastY = endY;
-            }
-            if (Math.abs(lastX - next.x) > 0.01 || Math.abs(lastY - next.y) > 0.01) {
-                d += ` L ${tx(next.x)} ${ty(next.y)}`;
-            }
-        }
-    }
-    d += " Z";
-    return d;
-};
-
-// Generate Ellipse/Arc Path with Cartesian -> SVG Conversion
-export const generateEllipsePath = (shape) => {
-    // Cartesian inputs
-    const { cx = 0, cy = 0, rx = 50, ry = 50, startAngle = 0, endAngle = 360, arcMode = 'sector', rotation = 0 } = shape;
-
-    // Convert to SVG coordinates
-    const cxs = cx * BASE_SCALE;
-    const cys = toSvgY(cy) * BASE_SCALE;
-    const rxs = rx * BASE_SCALE;
-    const rys = ry * BASE_SCALE;
-
-    // Angles: In Cartesian, angle increases CCW. In SVG (with Y-down), angle increases CW.
-    // To match visual appearance: angle_svg = -angle_cartesian.
-    // However, we also need to account for the fact that 0 degrees is East in both.
-    // Let's use standard math with flipped Y.
-    // x = cx + rx * cos(theta)
-    // y_cart = cy + ry * sin(theta)
-    // y_svg = -y_cart = -cy - ry * sin(theta) = cys - rys * sin(theta)
-    // In SVG path 'A' command, the coordinate system is local.
-    // Ideally we just calculate start/end points in SVG space.
-
-    // Start/End angles in Cartesian (CCW from East)
-    const startRad = (startAngle * Math.PI) / 180;
-    const endRad = (endAngle * Math.PI) / 180;
-
-    // Calculate start/end points in Cartesian, then convert to SVG
-    // x = cx + rx * cos(theta) (rotated by rotation)
-    // y = cy + ry * sin(theta) (rotated by rotation)
-
-    // Simplified approach: Calculate points in local unrotated space, then rotate, then translate, then flip Y.
-    // But SVG path 'A' command handles rotation.
-    // The rotation parameter in 'A' command is X-axis rotation.
-    // If we flip Y, the rotation direction effectively flips.
-    // SVG Rotation is CW. Cartesian Rotation is CCW.
-    // So svg_rotation = -cartesian_rotation.
-
-    // Calculate points in SVG Space directly
-    // P_svg = (cx, -cy) + (rx * cos(-theta), ry * sin(-theta))  <-- Wait, ry is radius, always positive.
-    // y_svg = -y_cart = - (cy + ry * sin(theta)) = -cy - ry * sin(theta).
-    // This is equivalent to Center(cx, -cy) + Radius(rx, ry) at Angle(-theta).
-    // So we use -startAngle and -endAngle.
-
-    const svgStartAngle = -startAngle;
-    const svgEndAngle = -endAngle;
-
-    // Normalize angles for arc calculation
-    // Note: SVG arcs go from start to end.
-    // If we go from -0 to -360 (CW), that's the same as 0 to 360 (CW in SVG).
-    // Cartesian 0 -> 90 (CCW) becomes SVG 0 -> -90 (CCW visually, or 360->270).
-
-    const startRadSvg = (svgStartAngle * Math.PI) / 180;
-    const endRadSvg = (svgEndAngle * Math.PI) / 180;
-
-    const x1 = cxs + rxs * Math.cos(startRadSvg);
-    const y1 = cys + rys * Math.sin(startRadSvg);
-    const x2 = cxs + rxs * Math.cos(endRadSvg);
-    const y2 = cys + rys * Math.sin(endRadSvg);
-
-    // Full ellipse check
-    const angleDiff = Math.abs(endAngle - startAngle); // Absolute difference in degrees
-    if (angleDiff >= 360) {
-        return `M ${cxs - rxs} ${cys} A ${rxs} ${rys} 0 1 1 ${cxs + rxs} ${cys} A ${rxs} ${rys} 0 1 1 ${cxs - rxs} ${cys}`;
-    }
-
-    // Large arc flag
-    // In SVG, large-arc-flag is 1 if angle > 180.
-    const largeArc = angleDiff > 180 ? 1 : 0;
-
-    // Sweep flag
-    // Cartesian: Start -> End is CCW.
-    // SVG Angles: -Start -> -End.
-    // Example: Start=0, End=90. SVG: 0 -> -90. Delta = -90.
-    // This is a "negative" sweep in standard math, but SVG sweep-flag=0 is CCW (negative angle direction), sweep-flag=1 is CW.
-    // Wait: SVG 'A' command: sweep-flag=1 means "positive-angle direction" (Clockwise in SVG Y-down).
-    // We want to draw from Start(0) to End(90 Cartesian).
-    // In SVG coords: (r, 0) to (0, -r).
-    // To go from (r,0) to (0,-r) via the "top-right" quadrant, we are moving CCW in screen space.
-    // In SVG (Y-down), moving (1,0) -> (0,-1) is...
-    // (1,0) is Right. (0,-1) is Up.
-    // Right -> Up is CCW (Counter-Clockwise).
-    // In SVG standard, angles increase CW (Right -> Down).
-    // So we are moving in the *negative* angle direction.
-    // So sweep-flag should be 0.
-
-    const sweepFlag = 0; // CCW for Cartesian positive angle direction
-
-    if (arcMode === 'sector') {
-        return `M ${cxs} ${cys} L ${x1} ${y1} A ${rxs} ${rys} 0 ${largeArc} ${sweepFlag} ${x2} ${y2} Z`;
-    } else {
-        return `M ${x1} ${y1} A ${rxs} ${rys} 0 ${largeArc} ${sweepFlag} ${x2} ${y2} Z`;
-    }
-};
-
 export const getClientPos = (e, viewState, svgRect) => {
     const cx = e.clientX - svgRect.left;
     const cy = e.clientY - svgRect.top;
     const x = (cx - viewState.x) / viewState.scale / BASE_SCALE;
     const ySvg = (cy - viewState.y) / viewState.scale / BASE_SCALE;
+    // import toCartesianY via re-export, but since it's re-exported here we can't easily import it inside.
+    // However, it's re-exported from this file! But we need it. Let's just use the logic directly or import it at top.
+    const toCartesianY = (y) => -y;
     // Convert SVG Y to Cartesian Y
     const y = toCartesianY(ySvg);
     return { x, y };
-};
-
-// Helper to rotate a point (px, py) around (cx, cy) by angle (degrees)
-const rotatePoint = (px, py, cx, cy, angle) => {
-    const rad = (angle * Math.PI) / 180;
-    const cos = Math.cos(rad);
-    const sin = Math.sin(rad);
-    const dx = px - cx;
-    const dy = py - cy;
-    return {
-        x: cx + dx * cos - dy * sin,
-        y: cy + dx * sin + dy * cos
-    };
-};
-
-export const getRotatedAABB = (shape) => {
-    if (!shape) return null;
-
-    // Handle Ellipse / Circle / Arc / Sector
-    if (shape.type === 'ellipse' || shape.type === 'circle' || shape.type === 'arc') {
-        const cx = shape.cx !== undefined ? shape.cx : (shape.x + shape.w / 2);
-        const cy = shape.cy !== undefined ? shape.cy : (shape.y + shape.h / 2);
-        const rx = shape.rx !== undefined ? shape.rx : (shape.w / 2);
-        const ry = shape.ry !== undefined ? shape.ry : (shape.h / 2);
-        const rotation = shape.rotation || 0;
-        const startAngle = shape.startAngle !== undefined ? shape.startAngle : 0;
-        const endAngle = shape.endAngle !== undefined ? shape.endAngle : 360;
-        const isSector = shape.arcMode === 'sector' || (shape.type === 'circle' && shape.arcMode !== 'chord');
-
-        const rotRad = (rotation * Math.PI) / 180;
-        const cosRot = Math.cos(rotRad);
-        const sinRot = Math.sin(rotRad);
-
-        const getPoint = (tDeg) => {
-            const tRad = (tDeg * Math.PI) / 180;
-            const x0 = rx * Math.cos(tRad);
-            const y0 = ry * Math.sin(tRad);
-            const xRot = x0 * cosRot - y0 * sinRot;
-            const yRot = x0 * sinRot + y0 * cosRot;
-            return { x: cx + xRot, y: cy + yRot };
-        };
-
-        let pointsToCheck = [];
-
-        pointsToCheck.push(getPoint(startAngle));
-        pointsToCheck.push(getPoint(endAngle));
-
-        if (isSector) {
-             pointsToCheck.push({ x: cx, y: cy });
-        }
-
-        const calcExtremaAngles = (isX) => {
-            let t = [];
-            if (isX) {
-                if (Math.abs(cosRot) < 1e-9) {
-                     t.push(90, 270);
-                } else {
-                    const val = -(ry * sinRot) / (rx * cosRot);
-                    const angle1 = Math.atan(val) * 180 / Math.PI;
-                    t.push(angle1, angle1 + 180);
-                }
-            } else {
-                if (Math.abs(sinRot) < 1e-9) {
-                    t.push(90, 270);
-                } else {
-                    const val = (ry * cosRot) / (rx * sinRot);
-                    const angle1 = Math.atan(val) * 180 / Math.PI;
-                    t.push(angle1, angle1 + 180);
-                }
-            }
-            return t.map(a => (a + 360) % 360);
-        };
-
-        const xExtrema = calcExtremaAngles(true);
-        const yExtrema = calcExtremaAngles(false);
-        const allExtrema = [...xExtrema, ...yExtrema];
-
-        let start = startAngle;
-        let end = endAngle;
-
-        const isAngleInArc = (angle) => {
-             const a = (angle % 360 + 360) % 360;
-             const s = (start % 360 + 360) % 360;
-             const e = (end % 360 + 360) % 360;
-             if (s <= e) {
-                 return a >= s && a <= e;
-             } else {
-                 return a >= s || a <= e;
-             }
-        };
-
-        const sweep = Math.abs(end - start);
-        if (sweep >= 360) {
-            allExtrema.forEach((t) => {
-                pointsToCheck.push(getPoint(t));
-            });
-        } else {
-            allExtrema.forEach(t => {
-                if (isAngleInArc(t)) {
-                    pointsToCheck.push(getPoint(t));
-                }
-            });
-        }
-
-        if (pointsToCheck.length === 0) return null;
-        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-        pointsToCheck.forEach(p => {
-            if (p.x < minX) minX = p.x;
-            if (p.x > maxX) maxX = p.x;
-            if (p.y < minY) minY = p.y;
-            if (p.y > maxY) maxY = p.y;
-        });
-
-        return { minX, minY, maxX, maxY };
-    }
-
-    if (shape.points && shape.points.length > 0) {
-        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-        shape.points.forEach(p => {
-            if (p.x < minX) minX = p.x; if (p.x > maxX) maxX = p.x;
-            if (p.y < minY) minY = p.y; if (p.y > maxY) maxY = p.y;
-        });
-        const cx = minX + (maxX - minX) / 2;
-        const cy = minY + (maxY - minY) / 2;
-
-        const rotation = shape.rotation || 0;
-
-        let rPoints = [];
-        if (rotation === 0) {
-            rPoints = shape.points;
-        } else {
-            rPoints = shape.points.map(p => rotatePoint(p.x, p.y, cx, cy, rotation));
-        }
-
-        let rMinX = Infinity, rMinY = Infinity, rMaxX = -Infinity, rMaxY = -Infinity;
-        rPoints.forEach(p => {
-            if (p.x < rMinX) rMinX = p.x; if (p.x > rMaxX) rMaxX = p.x;
-            if (p.y < rMinY) rMinY = p.y; if (p.y > rMaxY) rMaxY = p.y;
-        });
-        return { minX: rMinX, minY: rMinY, maxX: rMaxX, maxY: rMaxY };
-    }
-
-    if (shape.x !== undefined && shape.w !== undefined) {
-        const cx = shape.x + shape.w / 2;
-        const cy = shape.y + shape.h / 2;
-        const rotation = shape.rotation || 0;
-        const pts = [
-            { x: shape.x, y: shape.y },
-            { x: shape.x + shape.w, y: shape.y },
-            { x: shape.x + shape.w, y: shape.y + shape.h },
-            { x: shape.x, y: shape.y + shape.h }
-        ];
-        const rPoints = pts.map(p => rotatePoint(p.x, p.y, cx, cy, rotation));
-        let rMinX = Infinity, rMinY = Infinity, rMaxX = -Infinity, rMaxY = -Infinity;
-        rPoints.forEach(p => {
-            if (p.x < rMinX) rMinX = p.x; if (p.x > rMaxX) rMaxX = p.x;
-            if (p.y < rMinY) rMinY = p.y; if (p.y > rMaxY) rMaxY = p.y;
-        });
-        return { minX: rMinX, minY: rMinY, maxX: rMaxX, maxY: rMaxY };
-    }
-
-    return null;
-};
-
-export const calculateAssetBounds = (entities) => {
-    if (!entities || entities.length === 0) return null;
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    let hasValid = false;
-
-    entities.forEach(s => {
-        const box = getRotatedAABB(s);
-        if (box) {
-            hasValid = true;
-            if (box.minX < minX) minX = box.minX;
-            if (box.maxX > maxX) maxX = box.maxX;
-            if (box.minY < minY) minY = box.minY;
-            if (box.maxY > maxY) maxY = box.maxY;
-        }
-    });
-
-    if (hasValid && minX !== Infinity) {
-        return {
-            boundX: Math.round(minX),
-            boundY: Math.round(minY),
-            w: Math.round(maxX - minX),
-            h: Math.round(maxY - minY)
-        };
-    }
-    return null;
 };


### PR DESCRIPTION
This pull request kicks off the structural documentation and first phase of refactoring for `roomGenerator` as requested. 

First, it creates a comprehensive system map and plan in `docs/refactoring/ANALYSIS_AND_PLAN.md`, detailing the application's URLs, component tree, Zustand state management, and the Go backend's data structures.

Second, it acts on this plan with three specific refactoring improvements:
1. **Domain Logic Isolation:** Extracted math and geometry pure functions out of the general `utils.js` file into a dedicated `frontend/src/domain/geometry.js` file.
2. **Type Safety:** Documented the core data models (`Asset`, `Entity`, `Instance`, `Point`) using rigorous JSDoc type definitions in `assetService.js`, imported and referenced across domain files.
3. **Separation of Concerns:** Abstracted the heavy interaction logic (panning, dragging, marquee selection, bounds updates) from `DesignCanvas.jsx` into a new, testable custom hook (`useCanvasInteraction`). The `DesignCanvas` component now focuses purely on SVG rendering integration.

---
*PR created automatically by Jules for task [10749073734275542125](https://jules.google.com/task/10749073734275542125) started by @imohiyoko*