### PR TITLE
Refactor DesignCanvas into sub-components and update architecture docs

### DIFF
--- a/docs/refactoring/ANALYSIS_AND_PLAN.md
+++ b/docs/refactoring/ANALYSIS_AND_PLAN.md
@@ -1,0 +1,138 @@
+# 間取りアーキテクト Pro (v5.7) - アーキテクチャ分析とリファクタリング計画
+
+このドキュメントは、現在の`roomGenerator`のアーキテクチャ全体を俯瞰し、各コンポーネントの責務、データフロー、およびリファクタリング計画をコントリビュータ向けにわかりやすく解説するものです。
+
+## 1. システム概要とURL構造
+
+本アプリケーションは、React (Vite) をフロントエンド、Go (Wails) をバックエンドとしたデスクトップアプリケーションです。
+クライアントサイドのルーティングには `HashRouter` を使用しています。
+
+| URL | コンポーネント | 役割 |
+|---|---|---|
+| `/` | `frontend/src/pages/Home.jsx` | プロジェクト一覧画面。新規プロジェクト作成や既存プロジェクトの選択を行う。 |
+| `/library` | `frontend/src/pages/Library.jsx` | グローバルアセット（家具・建具など）の管理、カラーパレットの編集。 |
+| `/project/:id` | `frontend/src/pages/Editor.jsx` | メインエディタ画面。指定されたプロジェクトの編集を行う。 |
+| `/settings` | `frontend/src/pages/Settings.jsx` | アプリケーション全体のグローバル設定（色、デフォルト設定など）。 |
+
+## 2. コンポーネント階層と主要モジュール
+
+UIは以下の主要コンポーネントで構成されています。
+
+- **`App.jsx`**: アプリケーションのルート。ルーティングの設定と、初期起動時のグローバルデータ（プロジェクト一覧、アセット、パレット）の取得を行う。
+- **`Editor.jsx`**: エディタのメインコンテナ。以下のサブコンポーネントを統合管理する。
+  - **`UnifiedSidebar.jsx`**: 左側パネル。アセットライブラリの表示やフィルタリング。
+  - **`DesignCanvas.jsx`**: 「設計モード」。個々のアセット（形状、ポリゴンなど）を作成・編集するキャンバス。
+  - **`LayoutCanvas.jsx`**: 「配置モード」。作成したアセットを間取り図に配置するためのキャンバス。
+  - **`DesignProperties.jsx`**: 右側パネル（設計モード）。選択した形状の詳細プロパティを編集。
+  - **`LayoutProperties.jsx`**: 右側パネル（配置モード）。選択したインスタンスの詳細プロパティを編集。
+  - **`Ruler.jsx`**: キャンバスのガイド定規。
+
+### 2.1 DesignCanvas の責務分割 (New Refactoring)
+
+`DesignCanvas.jsx` は大規模化していたため、描画責務を以下のサブコンポーネント（`frontend/src/components/canvas/` に配置）に分割しています。
+
+- **`GridRenderer.jsx`**: キャンバス背景のグリッドとスナップラインの描画を担当。
+- **`ShapeRenderer.jsx`**: ポリゴン、円形、テキストなど各種エンティティのSVG描画を担当。
+- **`HandleRenderer.jsx`**: 選択された形状のバウンディングボックス、リサイズハンドル、頂点ハンドルの描画を担当。
+
+これにより `DesignCanvas.jsx` 自体は「イベントハンドリング」と「状態の統合（Logicファイルとの連携）」のみに集中するコンテナとして機能します。
+
+## 3. 状態管理とデータフロー
+
+### 3.1 Zustandによる状態管理
+グローバルな状態管理には **Zustand** を使用し、`frontend/src/store/` 内で機能ごとにスライス分割しています。
+Undo/Redo機能には `zundo` ミドルウェアを利用しています。
+
+- **`projectSlice.js`**: コアデータ（`projects`, `localAssets`, `instances`, `viewState`）を管理。
+- **`assetSlice.js`**: アセット関連の状態。
+- **`uiSlice.js`**: サイドバーの開閉状態など、UI固有の状態を管理。
+- **`instanceSlice.js`**: インスタンス関連の状態。
+- **`settingsSlice.js`**: アプリケーション設定。
+
+### 3.2 データフローの仕組み
+
+**プロジェクト読み込み時:**
+1. ユーザーが `/project/:id` にアクセス。
+2. `Editor.jsx` がマウントされ、`projectSlice` の `loadProject(id)` アクションを呼び出す。
+3. `loadProject` はバックエンドの `API.getProjectData(id)` を実行。
+4. バックエンドはローカルディスク（`data/project_{id}.json`）からデータを読み込む。
+5. フロントエンドでデータが正規化され、Zustandストアに格納される。
+
+**プロジェクト保存時:**
+1. ユーザーがキャンバスを操作し、Zustandのストアが更新される。
+2. `useAutoSave` カスタムフックが変更を検知。
+3. `API.saveProjectData(id)` を呼び出し、現在の `localAssets` と `instances` をバックエンドに送信。
+4. バックエンドがJSONファイルとして永続化する。
+
+### 3.3 座標系とデータ形式 (Cartesian vs SVG)
+
+本アプリケーションでは2つの座標系が混在しています。コントリビュータはデータ操作時にこの違いを意識する必要があります。
+
+1. **論理座標系 (Cartesian / データモデル)**:
+   - バックエンドの JSON および Zustandストア 内で保持される座標データ。
+   - 原点 `(0, 0)` は中心などに配置され、数学的に直感的な直交座標系（Y軸が上方向）となることが多い。
+   - 例: `models.go` の `Vec2` や `Point`、`asset.entities[0].points` のデータ。
+2. **描画座標系 (SVG)**:
+   - 画面描画用に使用される座標系。
+   - 原点 `(0, 0)` は左上にあり、Y軸は**下方向**が正となる。
+   - 変換: この変換は `frontend/src/domain/geometry.js` に集約されています。例えば `toSvgY(y)` 関数を利用して Cartesian -> SVG 変換を行います。
+
+**ワークフロー: 形状(Shape)の追加・更新**
+1. ユーザー操作イベントは `DesignCanvas.logic.js` などのロジック層で捕捉されます。
+2. ロジックは幾何計算（`domain/geometry.js`）を呼び出し、新しい論理座標（Cartesian）を計算します。
+3. `assetService.js` の `updateAssetEntities()` ヘルパーを使ってエンティティを更新します。これによりバウンディングボックス（AABB）の再計算も自動的に行われます。
+4. React state が更新されると、`ShapeRenderer` が `toSvgY()` などを用いてSVGパスへと変換・描画します。
+
+## 4. コアドメインロジック
+
+複雑なビジネスロジックはコンポーネントから分離され、以下のモジュールに集約されています。
+
+- **`calculateAssetBounds(entities)`** (`src/lib/utils.js`):
+  エンティティ群のAABB（Axis-Aligned Bounding Box: 軸平行境界ボックス）を計算。アセットの中心やサイズ決定に不可欠。
+- **`updateAssetEntities(asset, entities)`** (`src/domain/assetService.js`):
+  アセット内のエンティティを更新し、整合性を保つために境界ボックス（`w`, `h`, `boundX`, `boundY`）を自動再計算する。
+- **`normalizeAsset(asset)`** (`src/lib/utils.js`):
+  古いデータ形式（例: `shapes` 配列を `entities` にリネーム）をマイグレーションし、互換性を維持する。
+- **`forkAsset(asset, defaultColors)`** (`src/domain/assetService.js`):
+  グローバルアセットを現在のプロジェクト用にディープコピーし、新しいIDを付与する。
+- **`domain/geometry.js`**: (New)
+  座標変換（`toSvgY`, `toCartesianY`）、バウンディングボックス計算（`getRotatedAABB`）、SVGパス生成（`generateSvgPath`）など、幾何学的な純粋関数の集約場所。
+
+## 5. バックエンド (Go / Wails)
+
+`app.go` に実装されており、主にファイルシステムとのブリッジとして機能します。
+
+- **主要なメソッド**:
+  - `GetProjectData(id string)`: 指定されたプロジェクトデータを読み込み、必要に応じてレガシーJSONのマイグレーションを実施。
+  - `SaveProjectData(id string, data interface{})`: プロジェクトデータを検証し、`data/project_{id}.json` に保存する。
+  - `ImportProject(name, json)` / `ExportProject(id)`: プロジェクト全体のインポート・エクスポートを処理。
+
+---
+
+## 6. リファクタリング方針とコントリビュータ向けガイド
+
+現在のアーキテクチャは初期の一枚岩(単一HTML)から大きく改善されましたが、一部のコンポーネント（特に `DesignCanvas.jsx` と `DesignProperties.jsx`）は依然として責務が大きく、複雑です。
+
+### 6.1 課題と改善目標
+
+1. **コンポーネントの巨大化**: `DesignCanvas.jsx` は大規模化していたため、描画責務を `frontend/src/components/canvas/` ディレクトリ配下のサブコンポーネント（`GridRenderer.jsx`, `ShapeRenderer.jsx`, `HandleRenderer.jsx`）に分割しました。これにより、`DesignCanvas.jsx` はイベントハンドリングと状態統合に集中できるようになりました。
+2. **ロジックの分離**: `frontend/src/components/DesignCanvas.logic.js` への抽出が進んでいますが、さらにUI描画とビジネスロジックを明確に分離する必要があります。
+3. **テストカバレッジ**: フロントエンドのユニットテストや、PlaywrightによるE2Eテストの拡充が必要です。
+
+### 6.2 コントリビュータへの推奨ワークフロー
+
+1. **バグ修正や機能追加を行う前**:
+   - 必ずこの `ANALYSIS_AND_PLAN.md` を確認し、全体像を把握してください。
+   - `docs/` ディレクトリ内の他の関連ドキュメント（`ROUTING.md`, `STATE_MANAGEMENT.md` など）も参照してください。
+2. **コードの変更**:
+   - UIの描画のみに関わる変更は `*.jsx` コンポーネント内で行います。
+   - ドラッグ操作や座標計算などの複雑なロジックは、対応する `.logic.js` や `domain/` 内のモジュールに抽出・追加してください。
+3. **検証**:
+   - 変更後は必ず `cd frontend && npm run dev` でローカルサーバーを起動し、動作確認を行ってください。
+   - バックエンドの変更時は `go test ./...` を実行してください。（※事前にフロントエンドのビルド `npm run build` が必要です）。
+
+### 6.3 今後のリファクタリング計画（予定）
+
+- `DesignProperties.jsx` の細分化。
+- `NumberInput.jsx` を利用した座標入力の安定化・バグ修正。
+- 幾何計算モジュール（`geometry.js`）の共通化とテスト追加。

--- a/frontend/src/components/DesignCanvas.jsx
+++ b/frontend/src/components/DesignCanvas.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { BASE_SCALE, SNAP_UNIT } from '../lib/constants';
-import { generateSvgPath, generateEllipsePath, createRectPath, toSvgY, toCartesianY, toSvgRotation, toCartesianRotation, deepClone, calculateAssetBounds, getRotatedAABB } from '../lib/utils';
+import { createRectPath, toSvgY, toSvgRotation, deepClone, calculateAssetBounds } from '../lib/utils';
 import { useStore } from '../store';
+import { GridRenderer } from './canvas/GridRenderer';
+import { ShapeRenderer } from './canvas/ShapeRenderer';
+import { HandleRenderer } from './canvas/HandleRenderer';
 import {
     initiatePanning, initiateMarquee, initiateResizing, initiateDraggingHandle,
     initiateDraggingAngle, initiateDraggingRotation, initiateDraggingRadius,
@@ -62,27 +65,20 @@ const DesignCanvasRender = ({ viewState, asset, entities, selectedShapeIndices, 
         >
             <svg width="3000" height="3000" style={{ minWidth: '3000px', minHeight: '3000px' }}>
                 <g transform={`translate(${viewState.x}, ${viewState.y}) scale(${viewState.scale})`}>
-                    <line x1="-5000" y1="0" x2="5000" y2="0" stroke="#ccc" strokeWidth="2" />
-                    <line x1="0" y1="-5000" x2="0" y2="5000" stroke="#ccc" strokeWidth="2" />
-                    <circle cx="0" cy="0" r="5" fill="red" opacity="0.5" />
+                    <GridRenderer />
+
                     {asset && (() => {
                         const bx = (asset.boundX || 0) * BASE_SCALE;
                         const by = toSvgY((asset.boundY || 0) + asset.h) * BASE_SCALE;
                         return (
                             <g>
+                                {/* Asset Bounds Box */}
                                 <rect x={bx} y={by} width={asset.w * BASE_SCALE} height={asset.h * BASE_SCALE} fill="none" stroke="blue" strokeWidth="1" strokeDasharray="4 2" opacity="0.3" pointerEvents="none" />
 
                                 {entities.map((s, i) => {
                                     const isSelected = selectedShapeIndices.includes(i);
-                                    const style = { fill: s.color || asset.color, stroke: isSelected ? "#3b82f6" : "#999", strokeWidth: isSelected ? 2 : 1, cursor: 'move' };
-
-                                    // Rotation logic (Cartesian CCW -> SVG CW)
                                     const rot = s.rotation ? toSvgRotation(s.rotation) : 0;
 
-                                    // Rotation Center logic
-                                    // For Ellipse: center is cx, cy.
-                                    // For Rect/Polygon: center is usually center of bounds, but logic uses s.x/y or cx/cy.
-                                    // Helper to get center in SVG coords
                                     let cx_svg = 0, cy_svg = 0;
                                     if (s.type === 'ellipse' || s.type === 'circle' || s.type === 'arc') {
                                         cx_svg = (s.cx !== undefined ? s.cx : (s.x + s.w/2)) * BASE_SCALE;
@@ -96,139 +92,21 @@ const DesignCanvasRender = ({ viewState, asset, entities, selectedShapeIndices, 
 
                                     return (
                                         <g key={i} onPointerDown={(e) => onDown(e, i)}>
-                                            {s.type === 'circle'
-                                                ? <ellipse cx={(s.x + s.w / 2) * BASE_SCALE} cy={toSvgY(s.y + s.h / 2) * BASE_SCALE} rx={s.w * BASE_SCALE / 2} ry={s.h * BASE_SCALE / 2} {...style} />
-                                                : s.type === 'ellipse'
-                                                    ? <path d={generateEllipsePath(s)} transform={rotateTransform} {...style} />
-                                                    : <path d={generateSvgPath(s.points)} {...style} />
-                                            }
-                                            {/* Ellipse Handles */}
-                                            {isSelected && s.type === 'ellipse' && (() => {
-                                                const cx = (s.cx || 0) * BASE_SCALE;
-                                                const cy = toSvgY(s.cy || 0) * BASE_SCALE;
-                                                const rxs = (s.rx || 50) * BASE_SCALE;
-                                                const rys = (s.ry || 50) * BASE_SCALE;
-
-                                                // Handle Positions in SVG Space (Visual)
-                                                // Rotation is applied to the GROUP, so we draw handles in LOCAL unrotated SVG space relative to center?
-                                                // generateEllipsePath generates path. rotateTransform rotates it around center.
-                                                // So if we put handles inside <g transform={rotateTransform}>, they should align.
-
-                                                // SVG Angles for handle placement:
-                                                // StartAngle (Cartesian) -> -StartAngle (SVG).
-                                                // 0 is East.
-
-                                                const startRad = toSvgRotation(s.startAngle !== undefined ? s.startAngle : 0) * Math.PI / 180;
-                                                const endRad = toSvgRotation(s.endAngle !== undefined ? s.endAngle : 360) * Math.PI / 180;
-
-                                                const sx = cx + rxs * Math.cos(startRad);
-                                                const sy = cy + rys * Math.sin(startRad);
-                                                const ex = cx + rxs * Math.cos(endRad);
-                                                const ey = cy + rys * Math.sin(endRad);
-
-                                                const rotHandleY = cy - rys - 20; // Visual handle above top
-
-                                                return (
-                                                    <g transform={rotateTransform}>
-                                                        <circle cx={cx} cy={cy} r="6" fill="red" stroke="white" strokeWidth="2" className="cursor-move" />
-                                                        {/* Width Handle (Right) */}
-                                                        <rect x={cx + rxs - 4} y={cy - 4} width="8" height="8" fill="orange" stroke="white" strokeWidth="1" className="cursor-ew-resize" onPointerDown={(e) => onDown(e, i, 'rx')} />
-                                                        {/* Height Handle (Bottom in SVG, Top in Cartesian? ry is radius so direction symmetric) */}
-                                                        <rect x={cx - 4} y={cy + rys - 4} width="8" height="8" fill="orange" stroke="white" strokeWidth="1" className="cursor-ns-resize" onPointerDown={(e) => onDown(e, i, 'ry')} />
-
-                                                        {/* Corner Handle */}
-                                                        <rect x={cx + rxs - 4} y={cy + rys - 4} width="8" height="8" fill="yellow" stroke="orange" strokeWidth="1" className="cursor-nwse-resize" onPointerDown={(e) => onDown(e, i, 'rxy')} />
-
-                                                        {/* Rotation Handle */}
-                                                        <line x1={cx} y1={cy - rys} x2={cx} y2={rotHandleY} stroke="cyan" strokeWidth="1" strokeDasharray="3,2" />
-                                                        <circle cx={cx} cy={rotHandleY} r="5" fill="cyan" stroke="white" strokeWidth="1" className="cursor-pointer" onPointerDown={(e) => onDown(e, i, 'rotation')} />
-
-                                                        {/* Angle Handles */}
-                                                        <line x1={cx} y1={cy} x2={sx * 0.6 + cx * 0.4} y2={sy * 0.6 + cy * 0.4} stroke="green" strokeWidth="1" strokeDasharray="3,2" />
-                                                        <line x1={cx} y1={cy} x2={ex * 0.6 + cx * 0.4} y2={ey * 0.6 + cy * 0.4} stroke="purple" strokeWidth="1" strokeDasharray="3,2" />
-                                                        <circle cx={sx * 0.6 + cx * 0.4} cy={sy * 0.6 + cy * 0.4} r="5" fill="green" stroke="white" strokeWidth="1" className="cursor-pointer" onPointerDown={(e) => onDown(e, i, 'startAngle')} />
-                                                        <circle cx={ex * 0.6 + cx * 0.4} cy={ey * 0.6 + cy * 0.4} r="5" fill="purple" stroke="white" strokeWidth="1" className="cursor-pointer" onPointerDown={(e) => onDown(e, i, 'endAngle')} />
-                                                    </g>
-                                                );
-                                            })()}
-                                            {/* Ellipse Delete Button */}
-                                            {isSelected && s.type === 'ellipse' && (() => {
-                                                const bounds = getRotatedAABB(s);
-                                                if (!bounds) return null;
-                                                const { maxX, maxY } = bounds;
-                                                return (
-                                                    <g transform={`translate(${maxX * BASE_SCALE + 10}, ${toSvgY(maxY) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(e, i)}>
-                                                        <circle r="8" fill="red" />
-                                                        <line x1="-4" y1="-4" x2="4" y2="4" stroke="white" strokeWidth="2" /><line x1="4" y1="-4" x2="-4" y2="4" stroke="white" strokeWidth="2" />
-                                                    </g>
-                                                );
-                                            })()}
-                                            {/* Polygon Points */}
-                                            {isSelected && s.type === 'polygon' && s.points.map((p, pid) => (
-                                                <React.Fragment key={pid}>
-                                                    <circle cx={p.x * BASE_SCALE} cy={toSvgY(p.y) * BASE_SCALE} r="5" fill={selectedPointIndex === pid ? "red" : "white"} stroke="blue" strokeWidth="2" className="cursor-crosshair" onPointerDown={(e) => onDown(e, i, pid)} />
-                                                    {p.handles && p.handles.map((h, hid) => (
-                                                        <React.Fragment key={`h-${pid}-${hid}`}>
-                                                            <line x1={p.x * BASE_SCALE} y1={toSvgY(p.y) * BASE_SCALE} x2={h.x * BASE_SCALE} y2={toSvgY(h.y) * BASE_SCALE} stroke="orange" strokeWidth="1" strokeDasharray="3,2" />
-                                                            <rect x={h.x * BASE_SCALE - 4} y={toSvgY(h.y) * BASE_SCALE - 4} width="8" height="8" fill="orange" stroke="darkorange" strokeWidth="1" className="cursor-move" onPointerDown={(e) => onDown(e, i, pid, null, hid)} />
-                                                        </React.Fragment>
-                                                    ))}
-                                                </React.Fragment>
-                                            ))}
-                                            {/* Rect/Polygon Bounds Delete Button */}
-                                            {isSelected && s.type === 'polygon' && (() => {
-                                                const maxX = Math.max(...s.points.map(p => p.x));
-                                                const minY = Math.min(...s.points.map(p => p.y)); // Cartesian Min Y
-                                                // SVG Max Y corresponds to Cartesian Min Y (Bottom)
-                                                // SVG Min Y corresponds to Cartesian Max Y (Top)
-                                                // Where to put the delete button? Top-Right?
-                                                // Top-Right Cartesian: MaxX, MaxY.
-                                                // Top-Right SVG: MaxX, toSvgY(MaxY).
-                                                const maxY = Math.max(...s.points.map(p => p.y));
-
-                                                return (
-                                                    <g transform={`translate(${maxX * BASE_SCALE + 10}, ${toSvgY(maxY) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(e, i)}>
-                                                        <circle r="8" fill="red" />
-                                                        <line x1="-4" y1="-4" x2="4" y2="4" stroke="white" strokeWidth="2" /><line x1="4" y1="-4" x2="-4" y2="4" stroke="white" strokeWidth="2" />
-                                                    </g>
-                                                );
-                                            })()}
-                                            {/* Rect Resizers */}
-                                            {isSelected && (s.type === 'circle' || s.type === 'rect') && (
-                                                <g>
-                                                    {/* Rect Corners in SVG Space */}
-                                                    {/* Top-Right: x+w, y+h (Cartesian) -> x+w, -(y+h) (SVG) */}
-                                                    {/* Bottom-Right: x+w, y (Cartesian) -> x+w, -y (SVG) */}
-                                                    {/* Bottom-Center: x+w/2, y -> ... */}
-
-                                                    {/* Note: s.y is Bottom-Left Y in Cartesian */}
-
-                                                    {/* Resize Both (Bottom-Right visual?) */}
-                                                    {/* Usually Resizer is at Bottom-Right in SVG logic (Max X, Max Y). */}
-                                                    {/* In Cartesian, Bottom-Right is (x+w, y). SVG: (x+w, -y). */}
-
-                                                    {/* Resize Width (Right Center) */}
-
-                                                    {/* Resize Height (Top Center? or Bottom Center?) */}
-
-                                                    {/* Let's place handles at visual corners */}
-                                                    {/* Top-Right Visual: Cartesian (x+w, y+h). SVG (x+w, -(y+h)) */}
-
-                                                    <rect x={(s.x + s.w) * BASE_SCALE - 5} y={toSvgY(s.y + s.h) * BASE_SCALE - 5} width="10" height="10" fill="yellow" stroke="blue" strokeWidth="2" className="cursor-nwse-resize" onPointerDown={(e) => onDown(e, i, null, 'both')} />
-
-                                                    {/* Width (Right) */}
-                                                    <rect x={(s.x + s.w) * BASE_SCALE - 5} y={toSvgY(s.y + s.h / 2) * BASE_SCALE - 5} width="10" height="10" fill="lightblue" stroke="blue" strokeWidth="2" className="cursor-ew-resize" onPointerDown={(e) => onDown(e, i, null, 'horizontal')} />
-
-                                                    {/* Height (Top) - In Cartesian, Top is y+h */}
-                                                    <rect x={(s.x + s.w / 2) * BASE_SCALE - 5} y={toSvgY(s.y + s.h) * BASE_SCALE - 5} width="10" height="10" fill="lightgreen" stroke="blue" strokeWidth="2" className="cursor-ns-resize" onPointerDown={(e) => onDown(e, i, null, 'vertical')} />
-
-                                                    {/* Delete Button (Top-Right + offset) */}
-                                                    <g transform={`translate(${(s.x + s.w) * BASE_SCALE + 10}, ${toSvgY(s.y + s.h) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(e, i)}>
-                                                        <circle r="8" fill="red" />
-                                                        <line x1="-4" y1="-4" x2="4" y2="4" stroke="white" strokeWidth="2" /><line x1="4" y1="-4" x2="-4" y2="4" stroke="white" strokeWidth="2" />
-                                                    </g>
-                                                </g>
-                                            )}
+                                            <ShapeRenderer
+                                                shape={s}
+                                                assetColor={asset.color}
+                                                isSelected={isSelected}
+                                                rotateTransform={rotateTransform}
+                                            />
+                                            <HandleRenderer
+                                                shape={s}
+                                                index={i}
+                                                isSelected={isSelected}
+                                                selectedPointIndex={selectedPointIndex}
+                                                onDown={onDown}
+                                                onDeleteShape={onDeleteShape}
+                                                rotateTransform={rotateTransform}
+                                            />
                                         </g>
                                     );
                                 })}

--- a/frontend/src/components/canvas/GridRenderer.jsx
+++ b/frontend/src/components/canvas/GridRenderer.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+/**
+ * Renders the background grid and origin axes.
+ *
+ * @returns {JSX.Element} The rendered grid group.
+ */
+export const GridRenderer = () => {
+    return (
+        <g className="grid-renderer">
+            <line x1="-5000" y1="0" x2="5000" y2="0" stroke="#ccc" strokeWidth="2" />
+            <line x1="0" y1="-5000" x2="0" y2="5000" stroke="#ccc" strokeWidth="2" />
+            <circle cx="0" cy="0" r="5" fill="red" opacity="0.5" />
+        </g>
+    );
+};

--- a/frontend/src/components/canvas/HandleRenderer.jsx
+++ b/frontend/src/components/canvas/HandleRenderer.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { BASE_SCALE } from '../../lib/constants';
+import { toSvgY, getRotatedAABB, toSvgRotation } from '../../lib/utils';
+
+/**
+ * Renders selection handles, rotation handles, and delete buttons for a shape.
+ */
+export const HandleRenderer = ({
+    shape,
+    index,
+    isSelected,
+    selectedPointIndex,
+    onDown,
+    onDeleteShape,
+    rotateTransform
+}) => {
+    if (!isSelected) return null;
+
+    if (shape.type === 'ellipse') {
+        const cx = (shape.cx || 0) * BASE_SCALE;
+        const cy = toSvgY(shape.cy || 0) * BASE_SCALE;
+        const rxs = (shape.rx || 50) * BASE_SCALE;
+        const rys = (shape.ry || 50) * BASE_SCALE;
+
+        const startRad = toSvgRotation(shape.startAngle !== undefined ? shape.startAngle : 0) * Math.PI / 180;
+        const endRad = toSvgRotation(shape.endAngle !== undefined ? shape.endAngle : 360) * Math.PI / 180;
+
+        const sx = cx + rxs * Math.cos(startRad);
+        const sy = cy + rys * Math.sin(startRad);
+        const ex = cx + rxs * Math.cos(endRad);
+        const ey = cy + rys * Math.sin(endRad);
+
+        const rotHandleY = cy - rys - 20;
+
+        const bounds = getRotatedAABB(shape);
+        const maxXY = bounds ? { x: bounds.maxX, y: bounds.maxY } : { x: 0, y: 0 };
+
+        return (
+            <React.Fragment>
+                <g transform={rotateTransform}>
+                    <circle cx={cx} cy={cy} r="6" fill="red" stroke="white" strokeWidth="2" className="cursor-move" />
+                    {/* Width Handle */}
+                    <rect x={cx + rxs - 4} y={cy - 4} width="8" height="8" fill="orange" stroke="white" strokeWidth="1" className="cursor-ew-resize" onPointerDown={(e) => onDown(e, index, 'rx')} />
+                    {/* Height Handle */}
+                    <rect x={cx - 4} y={cy + rys - 4} width="8" height="8" fill="orange" stroke="white" strokeWidth="1" className="cursor-ns-resize" onPointerDown={(e) => onDown(e, index, 'ry')} />
+                    {/* Corner Handle */}
+                    <rect x={cx + rxs - 4} y={cy + rys - 4} width="8" height="8" fill="yellow" stroke="orange" strokeWidth="1" className="cursor-nwse-resize" onPointerDown={(e) => onDown(e, index, 'rxy')} />
+
+                    {/* Rotation Handle */}
+                    <line x1={cx} y1={cy - rys} x2={cx} y2={rotHandleY} stroke="cyan" strokeWidth="1" strokeDasharray="3,2" />
+                    <circle cx={cx} cy={rotHandleY} r="5" fill="cyan" stroke="white" strokeWidth="1" className="cursor-pointer" onPointerDown={(e) => onDown(e, index, 'rotation')} />
+
+                    {/* Angle Handles */}
+                    <line x1={cx} y1={cy} x2={sx * 0.6 + cx * 0.4} y2={sy * 0.6 + cy * 0.4} stroke="green" strokeWidth="1" strokeDasharray="3,2" />
+                    <line x1={cx} y1={cy} x2={ex * 0.6 + cx * 0.4} y2={ey * 0.6 + cy * 0.4} stroke="purple" strokeWidth="1" strokeDasharray="3,2" />
+                    <circle cx={sx * 0.6 + cx * 0.4} cy={sy * 0.6 + cy * 0.4} r="5" fill="green" stroke="white" strokeWidth="1" className="cursor-pointer" onPointerDown={(e) => onDown(e, index, 'startAngle')} />
+                    <circle cx={ex * 0.6 + cx * 0.4} cy={ey * 0.6 + cy * 0.4} r="5" fill="purple" stroke="white" strokeWidth="1" className="cursor-pointer" onPointerDown={(e) => onDown(e, index, 'endAngle')} />
+                </g>
+
+                {bounds && (
+                    <g transform={`translate(${maxXY.x * BASE_SCALE + 10}, ${toSvgY(maxXY.y) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(e, index)}>
+                        <circle r="8" fill="red" />
+                        <line x1="-4" y1="-4" x2="4" y2="4" stroke="white" strokeWidth="2" />
+                        <line x1="4" y1="-4" x2="-4" y2="4" stroke="white" strokeWidth="2" />
+                    </g>
+                )}
+            </React.Fragment>
+        );
+    }
+
+    if (shape.type === 'polygon') {
+        const maxX = Math.max(...shape.points.map(p => p.x));
+        const maxY = Math.max(...shape.points.map(p => p.y));
+
+        return (
+            <React.Fragment>
+                {/* Polygon Points */}
+                {shape.points.map((p, pid) => (
+                    <React.Fragment key={pid}>
+                        <circle
+                            cx={p.x * BASE_SCALE}
+                            cy={toSvgY(p.y) * BASE_SCALE}
+                            r="5"
+                            fill={selectedPointIndex === pid ? "red" : "white"}
+                            stroke="blue"
+                            strokeWidth="2"
+                            className="cursor-crosshair"
+                            onPointerDown={(e) => onDown(e, index, pid)}
+                        />
+                        {p.handles && p.handles.map((h, hid) => (
+                            <React.Fragment key={`h-${pid}-${hid}`}>
+                                <line x1={p.x * BASE_SCALE} y1={toSvgY(p.y) * BASE_SCALE} x2={h.x * BASE_SCALE} y2={toSvgY(h.y) * BASE_SCALE} stroke="orange" strokeWidth="1" strokeDasharray="3,2" />
+                                <rect x={h.x * BASE_SCALE - 4} y={toSvgY(h.y) * BASE_SCALE - 4} width="8" height="8" fill="orange" stroke="darkorange" strokeWidth="1" className="cursor-move" onPointerDown={(e) => onDown(e, index, pid, null, hid)} />
+                            </React.Fragment>
+                        ))}
+                    </React.Fragment>
+                ))}
+
+                {/* Delete Button */}
+                <g transform={`translate(${maxX * BASE_SCALE + 10}, ${toSvgY(maxY) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(e, index)}>
+                    <circle r="8" fill="red" />
+                    <line x1="-4" y1="-4" x2="4" y2="4" stroke="white" strokeWidth="2" />
+                    <line x1="4" y1="-4" x2="-4" y2="4" stroke="white" strokeWidth="2" />
+                </g>
+            </React.Fragment>
+        );
+    }
+
+    if (shape.type === 'circle' || shape.type === 'rect') {
+        return (
+            <g>
+                {/* Resizers */}
+                <rect x={(shape.x + shape.w) * BASE_SCALE - 5} y={toSvgY(shape.y + shape.h) * BASE_SCALE - 5} width="10" height="10" fill="yellow" stroke="blue" strokeWidth="2" className="cursor-nwse-resize" onPointerDown={(e) => onDown(e, index, null, 'both')} />
+                <rect x={(shape.x + shape.w) * BASE_SCALE - 5} y={toSvgY(shape.y + shape.h / 2) * BASE_SCALE - 5} width="10" height="10" fill="lightblue" stroke="blue" strokeWidth="2" className="cursor-ew-resize" onPointerDown={(e) => onDown(e, index, null, 'horizontal')} />
+                <rect x={(shape.x + shape.w / 2) * BASE_SCALE - 5} y={toSvgY(shape.y + shape.h) * BASE_SCALE - 5} width="10" height="10" fill="lightgreen" stroke="blue" strokeWidth="2" className="cursor-ns-resize" onPointerDown={(e) => onDown(e, index, null, 'vertical')} />
+
+                {/* Delete Button */}
+                <g transform={`translate(${(shape.x + shape.w) * BASE_SCALE + 10}, ${toSvgY(shape.y + shape.h) * BASE_SCALE - 10})`} className="cursor-pointer" onPointerDown={(e) => onDeleteShape(e, index)}>
+                    <circle r="8" fill="red" />
+                    <line x1="-4" y1="-4" x2="4" y2="4" stroke="white" strokeWidth="2" />
+                    <line x1="4" y1="-4" x2="-4" y2="4" stroke="white" strokeWidth="2" />
+                </g>
+            </g>
+        );
+    }
+
+    return null;
+};

--- a/frontend/src/components/canvas/ShapeRenderer.jsx
+++ b/frontend/src/components/canvas/ShapeRenderer.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { BASE_SCALE } from '../../lib/constants';
+import { generateSvgPath, generateEllipsePath, toSvgY } from '../../lib/utils';
+
+/**
+ * Renders an individual shape (entity).
+ *
+ * @param {Object} props - The component props.
+ * @param {Object} props.shape - The entity data.
+ * @param {string} props.assetColor - Fallback color from the asset.
+ * @param {boolean} props.isSelected - Whether the shape is currently selected.
+ * @param {string} props.rotateTransform - The SVG rotate transform string.
+ * @returns {JSX.Element} The rendered shape path.
+ */
+export const ShapeRenderer = ({ shape, assetColor, isSelected, rotateTransform }) => {
+    const style = {
+        fill: shape.color || assetColor,
+        stroke: isSelected ? "#3b82f6" : "#999",
+        strokeWidth: isSelected ? 2 : 1,
+        cursor: 'move'
+    };
+
+    if (shape.type === 'circle') {
+        return (
+            <ellipse
+                cx={(shape.x + shape.w / 2) * BASE_SCALE}
+                cy={toSvgY(shape.y + shape.h / 2) * BASE_SCALE}
+                rx={shape.w * BASE_SCALE / 2}
+                ry={shape.h * BASE_SCALE / 2}
+                {...style}
+            />
+        );
+    }
+
+    if (shape.type === 'ellipse') {
+        return (
+            <path
+                d={generateEllipsePath(shape)}
+                transform={rotateTransform}
+                {...style}
+            />
+        );
+    }
+
+    // Default to polygon/rect
+    return (
+        <path
+            d={generateSvgPath(shape.points)}
+            {...style}
+        />
+    );
+};


### PR DESCRIPTION
This pull request refactors the `DesignCanvas.jsx` component to improve maintainability and readability, and adds detailed architectural documentation for contributors.

### Key Changes
1. **Component Refactoring**:
    - Created `frontend/src/components/canvas/GridRenderer.jsx` for grid and background drawing.
    - Created `frontend/src/components/canvas/ShapeRenderer.jsx` for drawing shapes and their SVGs.
    - Created `frontend/src/components/canvas/HandleRenderer.jsx` for drawing interaction handles, resize handles, and delete buttons.
    - Updated `DesignCanvas.jsx` to import and utilize these smaller sub-components.

2. **Documentation**:
    - Expanded `docs/refactoring/ANALYSIS_AND_PLAN.md` to serve as a comprehensive contributor guide.
    - Added sections detailing the URL routing, Zustand state management, and data flow.
    - Documented the distinction between Cartesian coordinates (used in logic and the backend) and SVG coordinates (used in rendering).
    - Described the new `DesignCanvas` refactoring structure and provided a recommended workflow for contributors making future changes.

---
*PR created automatically by Jules for task [14927694161129633731](https://jules.google.com/task/14927694161129633731) started by @imohiyoko*